### PR TITLE
Add commandset integration tests (40 tests, TUnit + Revit)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/mcp-servers-for-revit.sln
+++ b/mcp-servers-for-revit.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitMCPPlugin", "plugin\Re
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitMCPCommandSet", "commandset\RevitMCPCommandSet.csproj", "{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitMCPCommandSet.Tests", "tests\commandset\RevitMCPCommandSet.Tests.csproj", "{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug R20|Any CPU = Debug R20|Any CPU
@@ -81,6 +83,24 @@ Global
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R25|Any CPU.Build.0 = Release R25|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R26|Any CPU.ActiveCfg = Release R26|Any CPU
 		{A23E71AF-675B-41EE-9BD4-D4F3C8BA080D}.Release R26|Any CPU.Build.0 = Release R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R25|Any CPU.ActiveCfg = Debug.R25|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R25|Any CPU.Build.0 = Debug.R25|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R26|Any CPU.ActiveCfg = Debug.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R26|Any CPU.Build.0 = Debug.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R25|Any CPU.ActiveCfg = Release.R25|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R25|Any CPU.Build.0 = Release.R25|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R26|Any CPU.ActiveCfg = Release.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R26|Any CPU.Build.0 = Release.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R20|Any CPU.ActiveCfg = Debug.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R21|Any CPU.ActiveCfg = Debug.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R22|Any CPU.ActiveCfg = Debug.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R23|Any CPU.ActiveCfg = Debug.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Debug R24|Any CPU.ActiveCfg = Debug.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R20|Any CPU.ActiveCfg = Release.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R21|Any CPU.ActiveCfg = Release.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R22|Any CPU.ActiveCfg = Release.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R23|Any CPU.ActiveCfg = Release.R26|Any CPU
+		{E1F2D3C4-A5B6-7890-ABCD-EF1234567890}.Release R24|Any CPU.ActiveCfg = Release.R26|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/commandset/Architecture/CreateLevelTests.cs
+++ b/tests/commandset/Architecture/CreateLevelTests.cs
@@ -1,0 +1,214 @@
+using Autodesk.Revit.DB;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.Architecture;
+
+public class CreateLevelTests : RevitApiTest
+{
+    private static Document _doc;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        _doc = Application.NewProjectDocument(UnitSystem.Imperial);
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+    }
+
+    [Test]
+    public async Task CreateLevel_AtElevation_LevelExistsWithCorrectElevation()
+    {
+        double elevationMm = 3000;
+        double elevationFeet = elevationMm / 304.8;
+
+        using var tx = new Transaction(_doc, "Create Level");
+        tx.Start();
+
+        var level = Level.Create(_doc, elevationFeet);
+
+        tx.Commit();
+
+        await Assert.That(level).IsNotNull();
+        await Assert.That(level.Elevation).IsEqualTo(elevationFeet).Within(0.001);
+    }
+
+    [Test]
+    public async Task CreateLevel_SetName_NameIsApplied()
+    {
+        using var tx = new Transaction(_doc, "Create Level");
+        tx.Start();
+
+        var level = Level.Create(_doc, 20.0);
+        level.Name = "Test Level Custom";
+
+        tx.Commit();
+
+        await Assert.That(level.Name).IsEqualTo("Test Level Custom");
+    }
+
+    [Test]
+    public async Task CreateLevel_WithFloorPlan_ViewPlanCreated()
+    {
+        using var tx = new Transaction(_doc, "Create Level With Floor Plan");
+        tx.Start();
+
+        var level = Level.Create(_doc, 30.0);
+        level.Name = "Floor Plan Level";
+
+        var floorPlanType = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewFamilyType))
+            .Cast<ViewFamilyType>()
+            .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+        ViewPlan floorPlan = null;
+        if (floorPlanType != null)
+        {
+            floorPlan = ViewPlan.Create(_doc, floorPlanType.Id, level.Id);
+        }
+
+        tx.Commit();
+
+        await Assert.That(floorPlan).IsNotNull();
+        await Assert.That(floorPlan.ViewType).IsEqualTo(ViewType.FloorPlan);
+    }
+
+    [Test]
+    public async Task CreateLevel_WithCeilingPlan_ViewPlanCreated()
+    {
+        using var tx = new Transaction(_doc, "Create Level With Ceiling Plan");
+        tx.Start();
+
+        var level = Level.Create(_doc, 40.0);
+        level.Name = "Ceiling Plan Level";
+
+        var ceilingPlanType = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewFamilyType))
+            .Cast<ViewFamilyType>()
+            .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.CeilingPlan);
+
+        ViewPlan ceilingPlan = null;
+        if (ceilingPlanType != null)
+        {
+            ceilingPlan = ViewPlan.Create(_doc, ceilingPlanType.Id, level.Id);
+        }
+
+        tx.Commit();
+
+        await Assert.That(ceilingPlan).IsNotNull();
+        await Assert.That(ceilingPlan.ViewType).IsEqualTo(ViewType.CeilingPlan);
+    }
+
+    [Test]
+    public async Task CreateLevel_DuplicateName_ExistingLevelFound()
+    {
+        using (var tx = new Transaction(_doc, "Create Original Level"))
+        {
+            tx.Start();
+            var original = Level.Create(_doc, 50.0);
+            original.Name = "Duplicate Test Level";
+            tx.Commit();
+        }
+
+        var existingLevels = new FilteredElementCollector(_doc)
+            .OfClass(typeof(Level))
+            .Cast<Level>()
+            .ToList();
+
+        var existing = existingLevels.FirstOrDefault(
+            l => l.Name.Equals("Duplicate Test Level", StringComparison.OrdinalIgnoreCase));
+
+        await Assert.That(existing).IsNotNull();
+        await Assert.That(existing.Name).IsEqualTo("Duplicate Test Level");
+    }
+
+    [Test]
+    public async Task CreateLevel_SetIsBuildingStory_ParameterValueSet()
+    {
+        using var tx = new Transaction(_doc, "Create Level Building Story");
+        tx.Start();
+
+        var level = Level.Create(_doc, 60.0);
+        level.Name = "Building Story Level";
+
+        var param = level.get_Parameter(BuiltInParameter.LEVEL_IS_BUILDING_STORY);
+        if (param != null && !param.IsReadOnly)
+        {
+            param.Set(0); // Set to NOT a building story
+        }
+
+        tx.Commit();
+
+        var readParam = level.get_Parameter(BuiltInParameter.LEVEL_IS_BUILDING_STORY);
+        await Assert.That(readParam).IsNotNull();
+        await Assert.That(readParam.AsInteger()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CreateLevel_MultipleLevels_AllCreatedAtCorrectElevations()
+    {
+        var elevationsMm = new[] { 0.0, 3000.0, 6000.0, 9000.0 };
+        var createdLevels = new List<Level>();
+
+        using var tx = new Transaction(_doc, "Create Multiple Levels");
+        tx.Start();
+
+        for (int i = 0; i < elevationsMm.Length; i++)
+        {
+            double elevFeet = elevationsMm[i] / 304.8;
+            var level = Level.Create(_doc, elevFeet);
+            level.Name = $"Batch Level {i}";
+            createdLevels.Add(level);
+        }
+
+        tx.Commit();
+
+        await Assert.That(createdLevels.Count).IsEqualTo(4);
+        for (int i = 0; i < elevationsMm.Length; i++)
+        {
+            double expectedFeet = elevationsMm[i] / 304.8;
+            await Assert.That(createdLevels[i].Elevation).IsEqualTo(expectedFeet).Within(0.001);
+        }
+    }
+
+    [Test]
+    public async Task CreateLevel_ElevationConversion_MmToFeetAccurate()
+    {
+        double elevationMm = 3048.0; // Exactly 10 feet
+        double elevationFeet = elevationMm / 304.8;
+
+        await Assert.That(elevationFeet).IsEqualTo(10.0).Within(0.0001);
+
+        double roundTrip = elevationFeet * 304.8;
+        await Assert.That(roundTrip).IsEqualTo(elevationMm).Within(0.0001);
+    }
+
+    [Test]
+    public async Task CreateLevel_RollbackOnFailure_LevelNotPersisted()
+    {
+        int levelCountBefore = new FilteredElementCollector(_doc)
+            .OfClass(typeof(Level))
+            .GetElementCount();
+
+        using (var tx = new Transaction(_doc, "Create Level Rollback"))
+        {
+            tx.Start();
+            Level.Create(_doc, 70.0);
+            tx.RollBack();
+        }
+
+        int levelCountAfter = new FilteredElementCollector(_doc)
+            .OfClass(typeof(Level))
+            .GetElementCount();
+
+        await Assert.That(levelCountAfter).IsEqualTo(levelCountBefore);
+    }
+}

--- a/tests/commandset/Architecture/CreateRoomTests.cs
+++ b/tests/commandset/Architecture/CreateRoomTests.cs
@@ -1,0 +1,292 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.Architecture;
+
+public class CreateRoomTests : RevitApiTest
+{
+    private static Document _doc;
+    private static Level _level;
+    private static ViewPlan _floorPlan;
+    private static Room _room;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        _doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using var tx = new Transaction(_doc, "Setup Room Test Environment");
+        tx.Start();
+
+        _level = Level.Create(_doc, 0.0);
+        _level.Name = "Room Test Level";
+
+        var floorPlanType = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewFamilyType))
+            .Cast<ViewFamilyType>()
+            .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+        if (floorPlanType != null)
+        {
+            _floorPlan = ViewPlan.Create(_doc, floorPlanType.Id, _level.Id);
+        }
+
+        // Create primary enclosure (0,0)-(10,10) with a room
+        CreateEnclosure(_doc, _level.Id, 0, 0, 10);
+        _room = _doc.Create.NewRoom(_level, new UV(5.0, 5.0));
+
+        // Create secondary enclosure (20,0)-(30,10) for rollback test
+        CreateEnclosure(_doc, _level.Id, 20, 0, 10);
+
+        tx.Commit();
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+    }
+
+    [Test]
+    public async Task CreateRoom_AtValidLocation_RoomExistsWithArea()
+    {
+        await Assert.That(_room).IsNotNull();
+        await Assert.That(_room.Area).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task CreateRoom_SetName_RoomNameParameterSet()
+    {
+        using var tx = new Transaction(_doc, "Set Room Name");
+        tx.Start();
+
+        var nameParam = _room.get_Parameter(BuiltInParameter.ROOM_NAME);
+        if (nameParam != null && !nameParam.IsReadOnly)
+        {
+            nameParam.Set("Conference Room");
+        }
+
+        tx.Commit();
+
+        var readParam = _room.get_Parameter(BuiltInParameter.ROOM_NAME);
+        await Assert.That(readParam?.AsString()).IsEqualTo("Conference Room");
+    }
+
+    [Test]
+    public async Task CreateRoom_SetNumber_RoomNumberParameterSet()
+    {
+        using var tx = new Transaction(_doc, "Set Room Number");
+        SuppressDuplicateNumberWarnings(tx);
+        tx.Start();
+
+        var numberParam = _room.get_Parameter(BuiltInParameter.ROOM_NUMBER);
+        if (numberParam != null && !numberParam.IsReadOnly)
+        {
+            numberParam.Set("101");
+        }
+
+        tx.Commit();
+
+        var readParam = _room.get_Parameter(BuiltInParameter.ROOM_NUMBER);
+        await Assert.That(readParam?.AsString()).IsEqualTo("101");
+    }
+
+    [Test]
+    public async Task CreateRoom_SetDepartmentAndComments_ParametersSet()
+    {
+        using var tx = new Transaction(_doc, "Set Room Dept");
+        tx.Start();
+
+        var deptParam = _room.get_Parameter(BuiltInParameter.ROOM_DEPARTMENT);
+        if (deptParam != null && !deptParam.IsReadOnly)
+        {
+            deptParam.Set("Engineering");
+        }
+
+        var commentsParam = _room.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+        if (commentsParam != null && !commentsParam.IsReadOnly)
+        {
+            commentsParam.Set("Test comment");
+        }
+
+        tx.Commit();
+
+        await Assert.That(_room.get_Parameter(BuiltInParameter.ROOM_DEPARTMENT)?.AsString())
+            .IsEqualTo("Engineering");
+        await Assert.That(_room.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.AsString())
+            .IsEqualTo("Test comment");
+    }
+
+    [Test]
+    public async Task CreateRoom_DuplicateNumber_UniqueNumberGenerated()
+    {
+        var existingNumbers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "200", "201", "202" };
+        string uniqueNumber = GetUniqueRoomNumber("200", existingNumbers);
+
+        await Assert.That(uniqueNumber).IsNotEqualTo("200");
+        await Assert.That(existingNumbers.Contains(uniqueNumber)).IsFalse();
+    }
+
+    [Test]
+    public async Task CreateRoom_MultipleRooms_AllGetUniqueNumbers()
+    {
+        var existingNumbers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var assignedNumbers = new List<string>();
+
+        for (int i = 0; i < 5; i++)
+        {
+            string number = GetNextAvailableRoomNumber(existingNumbers);
+            existingNumbers.Add(number);
+            assignedNumbers.Add(number);
+        }
+
+        // All numbers should be unique
+        await Assert.That(assignedNumbers.Distinct().Count()).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task CreateRoom_RollbackOnFailure_RoomNotPersisted()
+    {
+        int roomCountBefore = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Rooms)
+            .WhereElementIsNotElementType()
+            .GetElementCount();
+
+        using (var tx = new Transaction(_doc, "Create Room Rollback"))
+        {
+            tx.Start();
+            // Use secondary enclosure at (25, 5) so it doesn't conflict with _room
+            _doc.Create.NewRoom(_level, new UV(25.0, 5.0));
+            tx.RollBack();
+        }
+
+        int roomCountAfter = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Rooms)
+            .WhereElementIsNotElementType()
+            .GetElementCount();
+
+        await Assert.That(roomCountAfter).IsEqualTo(roomCountBefore);
+    }
+
+    [Test]
+    public async Task CreateRoom_UpperLimitAndOffset_ParametersSet()
+    {
+        using var tx = new Transaction(_doc, "Set Room Offset");
+        tx.Start();
+
+        double offsetMm = 3000;
+        double offsetFeet = offsetMm / 304.8;
+
+        var limitOffsetParam = _room.get_Parameter(BuiltInParameter.ROOM_UPPER_OFFSET);
+        if (limitOffsetParam != null && !limitOffsetParam.IsReadOnly)
+        {
+            limitOffsetParam.Set(offsetFeet);
+        }
+
+        tx.Commit();
+
+        var readParam = _room.get_Parameter(BuiltInParameter.ROOM_UPPER_OFFSET);
+        await Assert.That(readParam).IsNotNull();
+        await Assert.That(readParam.AsDouble()).IsEqualTo(3000.0 / 304.8).Within(0.001);
+    }
+
+    #region Helper Methods
+
+    private static void CreateEnclosure(Document doc, ElementId levelId, double x, double y, double size)
+    {
+        var p1 = new XYZ(x, y, 0);
+        var p2 = new XYZ(x + size, y, 0);
+        var p3 = new XYZ(x + size, y + size, 0);
+        var p4 = new XYZ(x, y + size, 0);
+
+        Wall.Create(doc, Line.CreateBound(p1, p2), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p2, p3), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p3, p4), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p4, p1), levelId, false);
+    }
+
+    private static void SuppressDuplicateNumberWarnings(Transaction tx)
+    {
+        var failureOptions = tx.GetFailureHandlingOptions();
+        failureOptions.SetClearAfterRollback(true);
+        failureOptions.SetDelayedMiniWarnings(false);
+        tx.SetFailureHandlingOptions(failureOptions);
+    }
+
+    private static string GetUniqueRoomNumber(string baseNumber, HashSet<string> existingNumbers)
+    {
+        if (string.IsNullOrEmpty(baseNumber))
+            baseNumber = "1";
+
+        if (!existingNumbers.Contains(baseNumber))
+            return baseNumber;
+
+        int lastDigitEnd = -1;
+        int lastDigitStart = -1;
+        for (int i = baseNumber.Length - 1; i >= 0; i--)
+        {
+            if (char.IsDigit(baseNumber[i]))
+            {
+                if (lastDigitEnd == -1) lastDigitEnd = i;
+                lastDigitStart = i;
+            }
+            else if (lastDigitEnd != -1)
+                break;
+        }
+
+        if (lastDigitStart != -1)
+        {
+            string prefix = baseNumber.Substring(0, lastDigitStart);
+            string numericPart = baseNumber.Substring(lastDigitStart, lastDigitEnd - lastDigitStart + 1);
+            string suffix = baseNumber.Substring(lastDigitEnd + 1);
+
+            if (int.TryParse(numericPart, out int num))
+            {
+                for (int i = 1; i <= 1000; i++)
+                {
+                    string candidate = prefix + (num + i).ToString().PadLeft(numericPart.Length, '0') + suffix;
+                    if (!existingNumbers.Contains(candidate))
+                        return candidate;
+                }
+            }
+        }
+
+        for (char c = 'A'; c <= 'Z'; c++)
+        {
+            string candidate = baseNumber + c;
+            if (!existingNumbers.Contains(candidate))
+                return candidate;
+        }
+
+        return baseNumber + "-" + Guid.NewGuid().ToString().Substring(0, 4);
+    }
+
+    private static string GetNextAvailableRoomNumber(HashSet<string> existingNumbers)
+    {
+        int maxNumber = 0;
+        foreach (string num in existingNumbers)
+        {
+            if (int.TryParse(num, out int parsed))
+            {
+                if (parsed > maxNumber) maxNumber = parsed;
+            }
+        }
+
+        for (int i = maxNumber + 1; i < maxNumber + 10000; i++)
+        {
+            string candidate = i.ToString();
+            if (!existingNumbers.Contains(candidate))
+                return candidate;
+        }
+
+        return (maxNumber + 1).ToString();
+    }
+
+    #endregion
+}

--- a/tests/commandset/AssemblyInfo.cs
+++ b/tests/commandset/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core.Executors;
+
+[assembly: TestExecutor<RevitThreadExecutor>]

--- a/tests/commandset/ColorSplashTests.cs
+++ b/tests/commandset/ColorSplashTests.cs
@@ -1,0 +1,209 @@
+using Autodesk.Revit.DB;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests;
+
+public class ColorSplashTests : RevitApiTest
+{
+    private static Document _doc;
+    private static Level _level;
+    private static ViewPlan _floorPlan;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        _doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using var tx = new Transaction(_doc, "Setup Color Splash Test Environment");
+        tx.Start();
+
+        _level = Level.Create(_doc, 0.0);
+        _level.Name = "Color Test Level";
+
+        var floorPlanType = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewFamilyType))
+            .Cast<ViewFamilyType>()
+            .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+        if (floorPlanType != null)
+        {
+            _floorPlan = ViewPlan.Create(_doc, floorPlanType.Id, _level.Id);
+        }
+
+        // Create walls with different types to test parameter grouping
+        var p1 = new XYZ(0, 0, 0);
+        var p2 = new XYZ(10, 0, 0);
+        var p3 = new XYZ(20, 0, 0);
+        var p4 = new XYZ(30, 0, 0);
+
+        Wall.Create(_doc, Line.CreateBound(p1, p2), _level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(p2, p3), _level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(p3, p4), _level.Id, false);
+
+        tx.Commit();
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+    }
+
+    [Test]
+    public async Task GroupElementsByParameter_WallComments_GroupsCorrectly()
+    {
+        // Set comments on walls to create groups
+        var walls = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Walls)
+            .WhereElementIsNotElementType()
+            .ToElements();
+
+        await Assert.That(walls.Count).IsGreaterThanOrEqualTo(3);
+
+        using (var tx = new Transaction(_doc, "Set Wall Comments"))
+        {
+            tx.Start();
+            int i = 0;
+            foreach (var wall in walls)
+            {
+                var param = wall.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                if (param != null && !param.IsReadOnly)
+                {
+                    param.Set(i < 2 ? "Group A" : "Group B");
+                }
+                i++;
+            }
+            tx.Commit();
+        }
+
+        // Group by parameter value (mimics handler logic)
+        var groups = new Dictionary<string, List<ElementId>>();
+        foreach (var wall in walls)
+        {
+            var param = wall.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+            string value = param?.HasValue == true ? param.AsString() ?? "None" : "None";
+
+            if (!groups.ContainsKey(value))
+                groups[value] = new List<ElementId>();
+            groups[value].Add(wall.Id);
+        }
+
+        await Assert.That(groups.ContainsKey("Group A")).IsTrue();
+        await Assert.That(groups.ContainsKey("Group B")).IsTrue();
+        await Assert.That(groups["Group A"].Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ApplyGraphicOverrides_SetColor_OverrideApplied()
+    {
+        await Assert.That(_floorPlan).IsNotNull();
+
+        var walls = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Walls)
+            .WhereElementIsNotElementType()
+            .ToElements();
+
+        await Assert.That(walls.Count).IsGreaterThan(0);
+
+        using var tx = new Transaction(_doc, "Apply Overrides");
+        tx.Start();
+
+        var color = new Color(255, 0, 0);
+        var overrides = new OverrideGraphicSettings();
+        overrides.SetProjectionLineColor(color);
+        overrides.SetSurfaceForegroundPatternColor(color);
+
+        var targetId = walls.First().Id;
+        _floorPlan.SetElementOverrides(targetId, overrides);
+
+        tx.Commit();
+
+        var applied = _floorPlan.GetElementOverrides(targetId);
+        await Assert.That((int)applied.ProjectionLineColor.Red).IsEqualTo(255);
+        await Assert.That((int)applied.ProjectionLineColor.Green).IsEqualTo(0);
+        await Assert.That((int)applied.ProjectionLineColor.Blue).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task FindSolidFillPattern_InDocument_PatternFound()
+    {
+        var solidFillId = ElementId.InvalidElementId;
+
+        var patterns = new FilteredElementCollector(_doc)
+            .OfClass(typeof(FillPatternElement))
+            .Cast<FillPatternElement>();
+
+        foreach (var patternElement in patterns)
+        {
+            var pattern = patternElement.GetFillPattern();
+            if (pattern.IsSolidFill)
+            {
+                solidFillId = patternElement.Id;
+                break;
+            }
+        }
+
+        await Assert.That(solidFillId).IsNotEqualTo(ElementId.InvalidElementId);
+    }
+
+    [Test]
+    public async Task CustomColorMapping_ArrayOfColors_MapsCorrectly()
+    {
+        var paramValues = new List<string> { "Value A", "Value B", "Value C" };
+        var customColors = new List<int[]>
+        {
+            new[] { 255, 0, 0 },
+            new[] { 0, 255, 0 },
+            new[] { 0, 0, 255 }
+        };
+
+        var colorMap = new Dictionary<string, int[]>();
+        for (int i = 0; i < paramValues.Count; i++)
+        {
+            if (i < customColors.Count)
+                colorMap[paramValues[i]] = customColors[i];
+        }
+
+        await Assert.That(colorMap["Value A"].SequenceEqual(new[] { 255, 0, 0 })).IsTrue();
+        await Assert.That(colorMap["Value B"].SequenceEqual(new[] { 0, 255, 0 })).IsTrue();
+        await Assert.That(colorMap["Value C"].SequenceEqual(new[] { 0, 0, 255 })).IsTrue();
+    }
+
+    [Test]
+    public async Task GradientColorGeneration_BlueToRed_InterpolatesCorrectly()
+    {
+        var paramValues = new List<string> { "Low", "Mid", "High" };
+        int[] startColor = { 0, 0, 180 };
+        int[] endColor = { 180, 0, 0 };
+
+        var colorMap = new Dictionary<string, int[]>();
+        for (int i = 0; i < paramValues.Count; i++)
+        {
+            double ratio = (double)i / (paramValues.Count - 1);
+            int[] color =
+            {
+                (int)(startColor[0] + (endColor[0] - startColor[0]) * ratio),
+                (int)(startColor[1] + (endColor[1] - startColor[1]) * ratio),
+                (int)(startColor[2] + (endColor[2] - startColor[2]) * ratio)
+            };
+            colorMap[paramValues[i]] = color;
+        }
+
+        // First should be blue (0,0,180)
+        await Assert.That(colorMap["Low"][0]).IsEqualTo(0);
+        await Assert.That(colorMap["Low"][2]).IsEqualTo(180);
+
+        // Last should be red (180,0,0)
+        await Assert.That(colorMap["High"][0]).IsEqualTo(180);
+        await Assert.That(colorMap["High"][2]).IsEqualTo(0);
+
+        // Mid should be interpolated (90,0,90)
+        await Assert.That(colorMap["Mid"][0]).IsEqualTo(90);
+        await Assert.That(colorMap["Mid"][2]).IsEqualTo(90);
+    }
+}

--- a/tests/commandset/DataExtraction/AnalyzeModelStatisticsTests.cs
+++ b/tests/commandset/DataExtraction/AnalyzeModelStatisticsTests.cs
@@ -1,0 +1,183 @@
+using Autodesk.Revit.DB;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.DataExtraction;
+
+public class AnalyzeModelStatisticsTests : RevitApiTest
+{
+    private static Document _doc;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        _doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using var tx = new Transaction(_doc, "Setup Statistics Test");
+        tx.Start();
+
+        // Create a level and some elements for statistics
+        var level = Level.Create(_doc, 0.0);
+        level.Name = "Stats Test Level";
+
+        var floorPlanType = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewFamilyType))
+            .Cast<ViewFamilyType>()
+            .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+        if (floorPlanType != null)
+        {
+            ViewPlan.Create(_doc, floorPlanType.Id, level.Id);
+        }
+
+        // Create walls to have some categorized elements
+        Wall.Create(_doc, Line.CreateBound(new XYZ(0, 0, 0), new XYZ(10, 0, 0)), level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(new XYZ(10, 0, 0), new XYZ(10, 10, 0)), level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(new XYZ(10, 10, 0), new XYZ(0, 10, 0)), level.Id, false);
+
+        tx.Commit();
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+    }
+
+    [Test]
+    public async Task TotalElementCount_MatchesFilteredElementCollector()
+    {
+        int totalElements = new FilteredElementCollector(_doc)
+            .WhereElementIsNotElementType()
+            .GetElementCount();
+
+        await Assert.That(totalElements).IsGreaterThan(0);
+
+        int totalTypes = new FilteredElementCollector(_doc)
+            .WhereElementIsElementType()
+            .GetElementCount();
+
+        await Assert.That(totalTypes).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task CategoryGrouping_ElementsGroupedByCategory_CountsCorrect()
+    {
+        var elements = new FilteredElementCollector(_doc)
+            .WhereElementIsNotElementType()
+            .ToElements();
+
+        var categoryGroups = new Dictionary<string, int>();
+        foreach (var elem in elements)
+        {
+            if (elem.Category == null) continue;
+            string catName = elem.Category.Name;
+
+            if (!categoryGroups.ContainsKey(catName))
+                categoryGroups[catName] = 0;
+            categoryGroups[catName]++;
+        }
+
+        // Should have at least walls category
+        await Assert.That(categoryGroups.Count).IsGreaterThan(0);
+
+        // Total of grouped counts should match elements with categories
+        int groupedTotal = categoryGroups.Values.Sum();
+        int elementsWithCategories = elements.Count(e => e.Category != null);
+        await Assert.That(groupedTotal).IsEqualTo(elementsWithCategories);
+    }
+
+    [Test]
+    public async Task LevelStatistics_ElevationAndElementCount_Populated()
+    {
+        var levels = new FilteredElementCollector(_doc)
+            .OfClass(typeof(Level))
+            .Cast<Level>()
+            .OrderBy(l => l.Elevation)
+            .ToList();
+
+        await Assert.That(levels.Count).IsGreaterThan(0);
+
+        foreach (var level in levels)
+        {
+            await Assert.That(level.Name).IsNotNullOrEmpty();
+
+            int elementCount = new FilteredElementCollector(_doc)
+                .WhereElementIsNotElementType()
+                .Where(e => e.LevelId == level.Id)
+                .Count();
+
+            // Element count should be non-negative
+            await Assert.That(elementCount).IsGreaterThanOrEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task ViewCounting_ExcludesTemplates_CountCorrect()
+    {
+        var allViews = new FilteredElementCollector(_doc)
+            .OfClass(typeof(View))
+            .Cast<View>()
+            .ToList();
+
+        int totalViewsExcludingTemplates = allViews.Count(v => !v.IsTemplate);
+        int templateCount = allViews.Count(v => v.IsTemplate);
+
+        await Assert.That(totalViewsExcludingTemplates).IsGreaterThan(0);
+        await Assert.That(totalViewsExcludingTemplates + templateCount).IsEqualTo(allViews.Count);
+    }
+
+    [Test]
+    public async Task DetailedTypeBreakdown_FamilyInstanceTypes_TrackedCorrectly()
+    {
+        var elements = new FilteredElementCollector(_doc)
+            .WhereElementIsNotElementType()
+            .ToElements();
+
+        var typeStats = new Dictionary<string, (string FamilyName, string TypeName, int Count)>();
+        var familyNames = new HashSet<string>();
+
+        foreach (var elem in elements)
+        {
+            if (elem is FamilyInstance fi)
+            {
+                string familyName = fi.Symbol?.Family?.Name;
+                string typeName = fi.Symbol?.Name;
+
+                if (!string.IsNullOrEmpty(familyName))
+                    familyNames.Add(familyName);
+
+                if (!string.IsNullOrEmpty(typeName))
+                {
+                    string key = $"{familyName}:{typeName}";
+                    if (typeStats.ContainsKey(key))
+                    {
+                        var existing = typeStats[key];
+                        typeStats[key] = (existing.FamilyName, existing.TypeName, existing.Count + 1);
+                    }
+                    else
+                    {
+                        typeStats[key] = (familyName, typeName, 1);
+                    }
+                }
+            }
+        }
+
+        // Validate that all tracked types have positive instance counts
+        foreach (var kvp in typeStats)
+        {
+            await Assert.That(kvp.Value.Count).IsGreaterThan(0);
+            await Assert.That(kvp.Value.TypeName).IsNotNullOrEmpty();
+        }
+
+        // Family names should be a subset of all families
+        foreach (var name in familyNames)
+        {
+            await Assert.That(name).IsNotNullOrEmpty();
+        }
+    }
+}

--- a/tests/commandset/DataExtraction/ExportRoomDataTests.cs
+++ b/tests/commandset/DataExtraction/ExportRoomDataTests.cs
@@ -1,0 +1,163 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.DataExtraction;
+
+public class ExportRoomDataTests : RevitApiTest
+{
+    private static Document _doc;
+    private static Level _level;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        _doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using var tx = new Transaction(_doc, "Setup Export Room Data Test");
+        tx.Start();
+
+        _level = Level.Create(_doc, 0.0);
+        _level.Name = "Export Test Level";
+
+        var floorPlanType = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewFamilyType))
+            .Cast<ViewFamilyType>()
+            .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+        if (floorPlanType != null)
+        {
+            ViewPlan.Create(_doc, floorPlanType.Id, _level.Id);
+        }
+
+        // Create enclosure and rooms
+        double size = 10.0;
+        var p1 = new XYZ(0, 0, 0);
+        var p2 = new XYZ(size, 0, 0);
+        var p3 = new XYZ(size, size, 0);
+        var p4 = new XYZ(0, size, 0);
+
+        Wall.Create(_doc, Line.CreateBound(p1, p2), _level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(p2, p3), _level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(p3, p4), _level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(p4, p1), _level.Id, false);
+
+        var room = _doc.Create.NewRoom(_level, new UV(5.0, 5.0));
+        if (room != null)
+        {
+            var nameParam = room.get_Parameter(BuiltInParameter.ROOM_NAME);
+            nameParam?.Set("Test Room");
+
+            var deptParam = room.get_Parameter(BuiltInParameter.ROOM_DEPARTMENT);
+            deptParam?.Set("Testing");
+        }
+
+        tx.Commit();
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+    }
+
+    [Test]
+    public async Task ExportRooms_PlacedRoom_NameNumberLevelAreaPopulated()
+    {
+        var rooms = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Rooms)
+            .WhereElementIsNotElementType()
+            .Cast<Room>()
+            .Where(r => r.Area > 0)
+            .ToList();
+
+        await Assert.That(rooms.Count).IsGreaterThan(0);
+
+        var room = rooms.First();
+        string name = room.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString() ?? "";
+        string number = room.Number ?? "";
+        string level = room.Level?.Name ?? "No Level";
+        double area = room.Area;
+
+        await Assert.That(name).IsNotNullOrEmpty();
+        await Assert.That(number).IsNotNullOrEmpty();
+        await Assert.That(level).IsNotEqualTo("No Level");
+        await Assert.That(area).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task ExportRooms_SkipUnplaced_UnplacedRoomsExcluded()
+    {
+        // Create an unplaced room
+        using (var tx = new Transaction(_doc, "Create Unplaced Room"))
+        {
+            tx.Start();
+            // NewRoom with phase creates an unplaced room
+            var phases = new FilteredElementCollector(_doc)
+                .OfClass(typeof(Phase))
+                .Cast<Phase>()
+                .ToList();
+            if (phases.Count > 0)
+            {
+                _doc.Create.NewRoom(phases.First());
+            }
+            tx.Commit();
+        }
+
+        var allRooms = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Rooms)
+            .WhereElementIsNotElementType()
+            .Cast<Room>()
+            .ToList();
+
+        // Filter like the handler does (skip Area == 0)
+        var placedRooms = allRooms.Where(r => r.Area > 0).ToList();
+
+        await Assert.That(placedRooms.Count).IsGreaterThan(0);
+        await Assert.That(placedRooms.Count).IsLessThanOrEqualTo(allRooms.Count);
+    }
+
+    [Test]
+    public async Task ExportRooms_IncludeUnplaced_AllRoomsReturned()
+    {
+        var allRooms = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Rooms)
+            .WhereElementIsNotElementType()
+            .Cast<Room>()
+            .ToList();
+
+        // When includeUnplacedRooms = true, no filtering on Area
+        bool includeUnplacedRooms = true;
+        var result = allRooms
+            .Where(r => includeUnplacedRooms || r.Area > 0)
+            .ToList();
+
+        await Assert.That(result.Count).IsEqualTo(allRooms.Count);
+    }
+
+    [Test]
+    public async Task ExportRooms_TotalAreaAccumulation_MatchesSumOfRoomAreas()
+    {
+        var rooms = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Rooms)
+            .WhereElementIsNotElementType()
+            .Cast<Room>()
+            .Where(r => r.Area > 0)
+            .ToList();
+
+        double totalArea = 0;
+        foreach (var room in rooms)
+        {
+            totalArea += room.Area;
+        }
+
+        double expectedTotal = rooms.Sum(r => r.Area);
+        await Assert.That(totalArea).IsEqualTo(expectedTotal).Within(0.001);
+        await Assert.That(totalArea).IsGreaterThan(0);
+    }
+}

--- a/tests/commandset/DataExtraction/GetMaterialQuantitiesTests.cs
+++ b/tests/commandset/DataExtraction/GetMaterialQuantitiesTests.cs
@@ -1,0 +1,169 @@
+using Autodesk.Revit.DB;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests.DataExtraction;
+
+public class GetMaterialQuantitiesTests : RevitApiTest
+{
+    private static Document _doc;
+    private static Level _level;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        _doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using var tx = new Transaction(_doc, "Setup Material Quantities Test");
+        tx.Start();
+
+        _level = Level.Create(_doc, 0.0);
+        _level.Name = "Material Test Level";
+
+        // Create walls that will have materials
+        Wall.Create(_doc, Line.CreateBound(new XYZ(0, 0, 0), new XYZ(10, 0, 0)), _level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(new XYZ(10, 0, 0), new XYZ(10, 10, 0)), _level.Id, false);
+        Wall.Create(_doc, Line.CreateBound(new XYZ(10, 10, 0), new XYZ(0, 10, 0)), _level.Id, false);
+
+        tx.Commit();
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+    }
+
+    [Test]
+    public async Task ExtractMaterials_FromWalls_MaterialNamesPopulated()
+    {
+        var walls = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Walls)
+            .WhereElementIsNotElementType()
+            .ToElements();
+
+        await Assert.That(walls.Count).IsGreaterThan(0);
+
+        var materialData = new Dictionary<ElementId, (string Name, string Class, double Area, double Volume, HashSet<ElementId> Elements)>();
+
+        foreach (var element in walls)
+        {
+            var materialIds = element.GetMaterialIds(false);
+            foreach (var matId in materialIds)
+            {
+                var material = _doc.GetElement(matId) as Material;
+                if (material == null) continue;
+
+                if (!materialData.ContainsKey(matId))
+                {
+                    materialData[matId] = (material.Name, material.MaterialClass, 0, 0, new HashSet<ElementId>());
+                }
+
+                double area = element.GetMaterialArea(matId, false);
+                double volume = element.GetMaterialVolume(matId);
+
+                var existing = materialData[matId];
+                materialData[matId] = (existing.Name, existing.Class, existing.Area + area, existing.Volume + volume, existing.Elements);
+                materialData[matId].Elements.Add(element.Id);
+            }
+        }
+
+        // Walls in a default template should have at least one material
+        await Assert.That(materialData.Count).IsGreaterThan(0);
+
+        foreach (var kvp in materialData)
+        {
+            await Assert.That(kvp.Value.Name).IsNotNullOrEmpty();
+        }
+    }
+
+    [Test]
+    public async Task FilterByCategory_WallsOnly_OnlyWallMaterialsReturned()
+    {
+        var builtInCategories = new List<BuiltInCategory> { BuiltInCategory.OST_Walls };
+        var filter = new ElementMulticategoryFilter(builtInCategories);
+
+        var elements = new FilteredElementCollector(_doc)
+            .WhereElementIsNotElementType()
+            .WherePasses(filter)
+            .ToElements();
+
+        // All returned elements should be walls
+        foreach (var element in elements)
+        {
+            await Assert.That(element.Category).IsNotNull();
+            await Assert.That(element.Category.Id.Value).IsEqualTo((long)BuiltInCategory.OST_Walls);
+        }
+    }
+
+    [Test]
+    public async Task MaterialAreaVolume_Accumulation_ValuesNonNegative()
+    {
+        var walls = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Walls)
+            .WhereElementIsNotElementType()
+            .ToElements();
+
+        double totalArea = 0;
+        double totalVolume = 0;
+
+        foreach (var element in walls)
+        {
+            var materialIds = element.GetMaterialIds(false);
+            foreach (var matId in materialIds)
+            {
+                double area = element.GetMaterialArea(matId, false);
+                double volume = element.GetMaterialVolume(matId);
+
+                await Assert.That(area).IsGreaterThanOrEqualTo(0);
+                await Assert.That(volume).IsGreaterThanOrEqualTo(0);
+
+                totalArea += area;
+                totalVolume += volume;
+            }
+        }
+
+        await Assert.That(totalArea).IsGreaterThanOrEqualTo(0);
+        await Assert.That(totalVolume).IsGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public async Task ElementCountPerMaterial_TracksUniqueElements()
+    {
+        var walls = new FilteredElementCollector(_doc)
+            .OfCategory(BuiltInCategory.OST_Walls)
+            .WhereElementIsNotElementType()
+            .ToElements();
+
+        var materialElementSets = new Dictionary<ElementId, HashSet<ElementId>>();
+
+        foreach (var element in walls)
+        {
+            var materialIds = element.GetMaterialIds(false);
+            foreach (var matId in materialIds)
+            {
+                if (!materialElementSets.ContainsKey(matId))
+                    materialElementSets[matId] = new HashSet<ElementId>();
+
+                materialElementSets[matId].Add(element.Id);
+            }
+        }
+
+        foreach (var kvp in materialElementSets)
+        {
+            // Element count should match the unique element set count
+            int elementCount = kvp.Value.Count;
+            await Assert.That(elementCount).IsGreaterThan(0);
+
+            // Adding the same element twice should not increase count
+            var testSet = new HashSet<ElementId>(kvp.Value);
+            int countBefore = testSet.Count;
+            testSet.Add(kvp.Value.First()); // Add duplicate
+            await Assert.That(testSet.Count).IsEqualTo(countBefore);
+        }
+    }
+}

--- a/tests/commandset/RevitMCPCommandSet.Tests.csproj
+++ b/tests/commandset/RevitMCPCommandSet.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Nice3point.Revit.Sdk/6.1.0">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Configurations>Debug.R25;Debug.R26</Configurations>
+    <Configurations>$(Configurations);Release.R25;Release.R26</Configurations>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
+    <PackageReference Include="Nice3point.TUnit.Revit" Version="$(RevitVersion).*" />
+  </ItemGroup>
+</Project>

--- a/tests/commandset/TagRoomsTests.cs
+++ b/tests/commandset/TagRoomsTests.cs
@@ -1,0 +1,202 @@
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Nice3point.TUnit.Revit;
+using Nice3point.TUnit.Revit.Executors;
+using TUnit.Core;
+using TUnit.Core.Executors;
+
+namespace RevitMCPCommandSet.Tests;
+
+public class TagRoomsTests : RevitApiTest
+{
+    private static Document _doc;
+    private static Level _level;
+    private static ViewPlan _floorPlan;
+    private static Room _room;
+
+    [Before(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Setup()
+    {
+        _doc = Application.NewProjectDocument(UnitSystem.Imperial);
+
+        using var tx = new Transaction(_doc, "Setup Tag Test Environment");
+        tx.Start();
+
+        _level = Level.Create(_doc, 0.0);
+        _level.Name = "Tag Test Level";
+
+        var floorPlanType = new FilteredElementCollector(_doc)
+            .OfClass(typeof(ViewFamilyType))
+            .Cast<ViewFamilyType>()
+            .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.FloorPlan);
+
+        if (floorPlanType != null)
+        {
+            _floorPlan = ViewPlan.Create(_doc, floorPlanType.Id, _level.Id);
+        }
+
+        // Create primary enclosure (0,0)-(10,10) with a room
+        CreateEnclosure(_doc, _level.Id, 0, 0, 10);
+        _room = _doc.Create.NewRoom(_level, new UV(5.0, 5.0));
+
+        // Create secondary enclosure (20,0)-(30,10) for multi-room test
+        CreateEnclosure(_doc, _level.Id, 20, 0, 10);
+
+        tx.Commit();
+    }
+
+    [After(HookType.Class)]
+    [HookExecutor<RevitThreadExecutor>]
+    public static void Cleanup()
+    {
+        _doc?.Close(false);
+    }
+
+    [Test]
+    public async Task TagRoom_CreateRoomTag_TagExists()
+    {
+        await Assert.That(_room).IsNotNull();
+        await Assert.That(_floorPlan).IsNotNull();
+
+        using var tx = new Transaction(_doc, "Tag Room");
+        tx.Start();
+
+        var locPoint = _room.Location as LocationPoint;
+        XYZ roomCenter = locPoint?.Point ?? new XYZ(5.0, 5.0, 0);
+        var tagPoint = new UV(roomCenter.X, roomCenter.Y);
+
+        var tag = _doc.Create.NewRoomTag(
+            new LinkElementId(_room.Id),
+            tagPoint,
+            _floorPlan.Id);
+
+        tx.Commit();
+
+        await Assert.That(tag).IsNotNull();
+        await Assert.That(tag.Room).IsNotNull();
+    }
+
+    [Test]
+    public async Task TagRoom_WithLeader_HasLeaderIsTrue()
+    {
+        await Assert.That(_room).IsNotNull();
+        await Assert.That(_floorPlan).IsNotNull();
+
+        using var tx = new Transaction(_doc, "Tag Room With Leader");
+        tx.Start();
+
+        var locPoint = _room.Location as LocationPoint;
+        XYZ roomCenter = locPoint?.Point ?? new XYZ(5.0, 5.0, 0);
+
+        var tag = _doc.Create.NewRoomTag(
+            new LinkElementId(_room.Id),
+            new UV(roomCenter.X, roomCenter.Y),
+            _floorPlan.Id);
+
+        if (tag != null)
+        {
+            tag.HasLeader = true;
+        }
+
+        tx.Commit();
+
+        await Assert.That(tag).IsNotNull();
+        await Assert.That(tag.HasLeader).IsTrue();
+    }
+
+    [Test]
+    public async Task TagRoom_SkipAlreadyTagged_NoDuplicateTags()
+    {
+        await Assert.That(_room).IsNotNull();
+        await Assert.That(_floorPlan).IsNotNull();
+
+        // Create a tag for the room
+        RoomTag firstTag;
+        using (var tx = new Transaction(_doc, "First Tag"))
+        {
+            tx.Start();
+            var locPoint = _room.Location as LocationPoint;
+            XYZ center = locPoint?.Point ?? new XYZ(5.0, 5.0, 0);
+            firstTag = _doc.Create.NewRoomTag(new LinkElementId(_room.Id), new UV(center.X, center.Y), _floorPlan.Id);
+            tx.Commit();
+        }
+
+        await Assert.That(firstTag).IsNotNull();
+
+        // Simulate duplicate detection (mimics handler logic)
+        var taggedRoomIds = new HashSet<long> { firstTag.Room.Id.Value };
+        bool alreadyTagged = taggedRoomIds.Contains(_room.Id.Value);
+
+        await Assert.That(alreadyTagged).IsTrue();
+    }
+
+    [Test]
+    public async Task TagRoom_SpecificRoomById_OnlyThatRoomTagged()
+    {
+        await Assert.That(_room).IsNotNull();
+        await Assert.That(_floorPlan).IsNotNull();
+
+        // Create a second room in the secondary enclosure
+        Room room2;
+        using (var tx = new Transaction(_doc, "Create Second Room"))
+        {
+            tx.Start();
+            room2 = _doc.Create.NewRoom(_level, new UV(25.0, 5.0));
+            tx.Commit();
+        }
+
+        await Assert.That(room2).IsNotNull();
+
+        // Tag only _room (room1)
+        RoomTag tag;
+        using (var tx = new Transaction(_doc, "Tag Specific Room"))
+        {
+            tx.Start();
+            var locPoint = _room.Location as LocationPoint;
+            XYZ center = locPoint?.Point ?? new XYZ(5.0, 5.0, 0);
+            tag = _doc.Create.NewRoomTag(new LinkElementId(_room.Id), new UV(center.X, center.Y), _floorPlan.Id);
+            tx.Commit();
+        }
+
+        // Verify the tag references the correct room (room1, not room2)
+        await Assert.That(tag).IsNotNull();
+        await Assert.That(tag.Room.Id.Value).IsEqualTo(_room.Id.Value);
+    }
+
+    [Test]
+    public async Task CreateRoomTag_TagReferencesRoom_TagTextNotEmpty()
+    {
+        await Assert.That(_room).IsNotNull();
+        await Assert.That(_floorPlan).IsNotNull();
+
+        // Create a tag and verify it references the room with displayable text
+        RoomTag tag;
+        using (var tx = new Transaction(_doc, "Create Tag For Text Test"))
+        {
+            tx.Start();
+            var locPoint = _room.Location as LocationPoint;
+            XYZ center = locPoint?.Point ?? new XYZ(5.0, 5.0, 0);
+            tag = _doc.Create.NewRoomTag(new LinkElementId(_room.Id), new UV(center.X, center.Y), _floorPlan.Id);
+            tx.Commit();
+        }
+
+        await Assert.That(tag).IsNotNull();
+        await Assert.That(tag.Room).IsNotNull();
+        await Assert.That(tag.Room.Id.Value).IsEqualTo(_room.Id.Value);
+        await Assert.That(tag.TagText).IsNotNull();
+    }
+
+    private static void CreateEnclosure(Document doc, ElementId levelId, double x, double y, double size)
+    {
+        var p1 = new XYZ(x, y, 0);
+        var p2 = new XYZ(x + size, y, 0);
+        var p3 = new XYZ(x + size, y + size, 0);
+        var p4 = new XYZ(x, y + size, 0);
+
+        Wall.Create(doc, Line.CreateBound(p1, p2), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p2, p3), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p3, p4), levelId, false);
+        Wall.Create(doc, Line.CreateBound(p4, p1), levelId, false);
+    }
+}


### PR DESCRIPTION
Adds a test project under tests/commandset.Tests/ using Nice3point.TUnit.Revit to run integration tests against a live Revit instance. Covers level creation, room creation, room tagging, color splash overrides, model statistics, room data export, and material quantities.