### PR TITLE
Add Revit 2027 (.NET 10) support

### DIFF
--- a/commandset/RevitMCPCommandSet.csproj
+++ b/commandset/RevitMCPCommandSet.csproj
@@ -6,8 +6,8 @@
         <PlatformTarget>x64</PlatformTarget>
         <ImplicitUsings>true</ImplicitUsings>
         <PublishAddinFiles>true</PublishAddinFiles>
-        <Configurations>Debug R20;Debug R21;Debug R22;Debug R23;Debug R24;Debug R25;Debug R26</Configurations>
-        <Configurations>$(Configurations);Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Release R26</Configurations>
+        <Configurations>Debug R20;Debug R21;Debug R22;Debug R23;Debug R24;Debug R25;Debug R26;Debug R27</Configurations>
+        <Configurations>$(Configurations);Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Release R26;Release R27</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(Configuration.Contains('R20'))">
@@ -44,6 +44,12 @@
         <DefineConstants>$(DefineConstants);REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER</DefineConstants>
     </PropertyGroup>
 
+    <PropertyGroup Condition="$(Configuration.Contains('R27'))">
+        <RevitVersion>2027</RevitVersion>
+        <TargetFramework>net10.0-windows7.0</TargetFramework>
+        <DefineConstants>$(DefineConstants);REVIT2022_OR_GREATER;REVIT2023_OR_GREATER;REVIT2024_OR_GREATER;REVIT2027_OR_GREATER</DefineConstants>
+    </PropertyGroup>
+
     <PropertyGroup>
         <StartAction>Program</StartAction>
         <StartProgram>C:\Program Files\Autodesk\Revit $(RevitVersion)\Revit.exe</StartProgram>
@@ -58,10 +64,17 @@
         <PackageReference Include="Nice3point.Revit.Extensions" Version="$(RevitVersion).*" />
         <PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
 		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*" />
-		<PackageReference Include="RevitMCPSDK" Version="$(RevitVersion).*" />
+		<PackageReference Include="RevitMCPSDK" Version="$(RevitVersion).*" Condition="!$(Configuration.Contains('R27'))" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="$(Configuration.Contains('R27'))">
+        <Reference Include="RevitMCPSDK">
+            <HintPath>$(MSBuildThisFileDirectory)..\..\RevitMCPSDK\RevitMCPSDK\bin\Release R27\net10.0-windows7.0\RevitMCPSDK.dll</HintPath>
+            <Private>true</Private>
+        </Reference>
+    </ItemGroup>
+
+    <ItemGroup Condition="!$(Configuration.Contains('R27'))">
       <Reference Include="System.Net.Http" />
     </ItemGroup>
 

--- a/commandset/Utils/GeometryUtils.cs
+++ b/commandset/Utils/GeometryUtils.cs
@@ -203,10 +203,21 @@ public static class GeometryUtils
     {
         // Implement algorithm to calculate intersection
         // Simple method: use Revit API to find intersection
+#if REVIT2027_OR_GREATER
+        var intersectResult = line1.Intersect(line2, CurveIntersectResultOption.Detailed);
+        if (intersectResult.Result == SetComparisonResult.Overlap)
+        {
+            var overlaps = intersectResult.GetOverlaps();
+            if (overlaps.Count > 0)
+                return overlaps[0].Point;
+        }
+        return null;
+#else
         var results = new IntersectionResultArray();
         if (line1.Intersect(line2, out results) == SetComparisonResult.Overlap && results.Size > 0)
             return results.get_Item(0).XYZPoint;
         return null;
+#endif
     }
 
     /// <summary>

--- a/plugin/RevitMCPPlugin.csproj
+++ b/plugin/RevitMCPPlugin.csproj
@@ -6,7 +6,7 @@
         <UseWindowsForms>true</UseWindowsForms>
         <UseWPF>true</UseWPF>
         <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-        <Configurations>Debug R20;Debug R21;Debug R22;Debug R24;Debug R25;Debug R26;Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Release R26;Debug R23</Configurations>
+        <Configurations>Debug R20;Debug R21;Debug R22;Debug R24;Debug R25;Debug R26;Debug R27;Release R20;Release R21;Release R22;Release R23;Release R24;Release R25;Release R26;Release R27;Debug R23</Configurations>
         <PlatformTarget>x64</PlatformTarget>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         
@@ -49,6 +49,12 @@
         <OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
         <EnableDynamicLoading>true</EnableDynamicLoading>
     </PropertyGroup>
+    <PropertyGroup Condition="$(Configuration.Contains('R27'))">
+        <RevitVersion>2027</RevitVersion>
+        <TargetFramework>net10.0-windows7.0</TargetFramework>
+        <OutputPath>bin\$(Configuration.Split(' ')[0])\$(RevitVersion)\</OutputPath>
+        <EnableDynamicLoading>true</EnableDynamicLoading>
+    </PropertyGroup>
     <PropertyGroup>
         <StartAction>Program</StartAction>
         <StartProgram>C:\Program Files\Autodesk\Revit $(RevitVersion)\Revit.exe</StartProgram>
@@ -58,7 +64,7 @@
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
         <PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*"/>
         <PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*"/>
-        <PackageReference Include="RevitMCPSDK" Version="$(RevitVersion).*"/>
+        <PackageReference Include="RevitMCPSDK" Version="$(RevitVersion).*" Condition="!$(Configuration.Contains('R27'))"/>
         <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0"/>
     </ItemGroup>
     <ItemGroup>
@@ -71,6 +77,12 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+    </ItemGroup>
+    <ItemGroup Condition="$(Configuration.Contains('R27'))">
+        <Reference Include="RevitMCPSDK">
+            <HintPath>$(MSBuildThisFileDirectory)..\..\RevitMCPSDK\RevitMCPSDK\bin\Release R27\net10.0-windows7.0\RevitMCPSDK.dll</HintPath>
+            <Private>true</Private>
+        </Reference>
     </ItemGroup>
     <ItemGroup>
         <None Update="mcp-servers-for-revit.addin">


### PR DESCRIPTION
## Summary

- Add R27 build configurations to `commandset` and `plugin` projects targeting `net10.0-windows7.0`
- Reference locally built RevitMCPSDK for R27 (NuGet `RevitMCPSDK` package not yet available for 2027 — see DTDucas/RevitMCPSDK#PR)
- Fix breaking Revit 2027 API change: `Curve.Intersect()` signature changed from `out IntersectionResultArray` to `CurveIntersectResultOption` / `CurveIntersectResult` — handled with `#if REVIT2027_OR_GREATER`
- Exclude redundant `System.Net.Http` reference for R27 (built into .NET 10)

## Test plan

- [x] Built successfully with `dotnet build commandset/RevitMCPCommandSet.csproj -c "Release R27"`
- [x] Built successfully with `dotnet build plugin/RevitMCPPlugin.csproj -c "Release R27"`
- [x] Add-in loads in Revit 2027 (MCP Switch visible in Add-Ins tab)
- [x] `say_hello` dialog confirmed in live Revit 2027 session (Snowdon Towers example)
- [x] All 23 commands registered and loading successfully

## Notes

Once `RevitMCPSDK` is published for 2027 on NuGet, the local DLL reference can be replaced with a standard `<PackageReference Include="RevitMCPSDK" Version="2027.*" />`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)