### PR TITLE
Raise default limit on list tools from 100 to 100000

### DIFF
--- a/server/src/tools/get_available_family_types.ts
+++ b/server/src/tools/get_available_family_types.ts
@@ -20,13 +20,15 @@ export function registerGetAvailableFamilyTypesTool(server: McpServer) {
       limit: z
         .number()
         .optional()
-        .describe("Maximum number of family types to return"),
+        .describe(
+          "Maximum number of family types to return. Defaults to 100000 so large family libraries are not silently truncated; pass a smaller value if you only need a sample."
+        ),
     },
     async (args, extra) => {
       const params = {
         categoryList: args.categoryList || [],
         familyNameFilter: args.familyNameFilter || "",
-        limit: args.limit || 100,
+        limit: args.limit || 100000,
       };
 
       try {

--- a/server/src/tools/get_current_view_elements.ts
+++ b/server/src/tools/get_current_view_elements.ts
@@ -26,14 +26,16 @@ export function registerGetCurrentViewElementsTool(server: McpServer) {
       limit: z
         .number()
         .optional()
-        .describe("Maximum number of elements to return"),
+        .describe(
+          "Maximum number of elements to return. Defaults to 100000 so real-world views are not silently truncated; pass a smaller value if you want a sample or are on a performance-constrained model."
+        ),
     },
     async (args, extra) => {
       const params = {
         modelCategoryList: args.modelCategoryList || [],
         annotationCategoryList: args.annotationCategoryList || [],
         includeHidden: args.includeHidden || false,
-        limit: args.limit || 100,
+        limit: args.limit || 100000,
       };
 
       try {

--- a/server/src/tools/get_selected_elements.ts
+++ b/server/src/tools/get_selected_elements.ts
@@ -10,11 +10,13 @@ export function registerGetSelectedElementsTool(server: McpServer) {
       limit: z
         .number()
         .optional()
-        .describe("Maximum number of elements to return"),
+        .describe(
+          "Maximum number of elements to return. Defaults to 100000 so a large user selection is not silently truncated; pass a smaller value if you only need a sample."
+        ),
     },
     async (args, extra) => {
       const params = {
-        limit: args.limit || 100,
+        limit: args.limit || 100000,
       };
 
       try {


### PR DESCRIPTION
## Summary

The three list-style MCP tools default to `limit: 100`, which silently truncates on any non-trivial Revit model:

- `get_current_view_elements` — default `limit: 100`
- `get_selected_elements` — default `limit: 100`
- `get_available_family_types` — default `limit: 100`

A caller asking *"how many doors are in the current view"* gets a response capped at 100 with no indication the data was cut. An LLM on the other end will happily quote that number as the total. In enterprise BIM use this becomes wrong takeoffs, wrong schedules, wrong coordination.

This PR raises all three defaults to `100000`, documents the change in the zod `describe` strings, and leaves the explicit-limit path untouched for callers who actually want a sample.

## Why 100000

- Safely above any realistic per-view / per-selection / per-family-library count (a floor plan with 142 doors is common; 100,000 anything is not).
- Small enough that a runaway tool call cannot exhaust memory before the JSON serializer catches it.
- Round, memorable, and easy to reason about from the call site.

## Backward compatibility

No breaking change. Callers who pass `limit: 50` (or any explicit value) still get exactly what they asked for — the default is only used when the caller omits the parameter.

## Scope

Pure server-side change. The C# addin has no hardcoded cap on any of these handlers; the 100-element default was introduced at the TS layer only. The addin accepts whatever integer limit arrives in the request body.

## Related

- `ai_element_filter` has a similar silent-cap pattern on a separate `maxElements` field. That needs to be addressed together with the C# side (`ReturnAllIfSearchFails` short-circuits `Take(maxElements)` which makes the total-count message unreliable). Happy to open a follow-up PR if maintainers would like — but the TS default-change is a clean, self-contained fix that can land independently.

## Test plan

- [x] `tsc --noEmit` passes on the server workspace after the change.
- [x] Default behavior verified: calling `get_current_view_elements` with no `limit` now returns the full view (up to 100000 elements) instead of being capped at 100.
- [x] Explicit limit preserved: calling with `limit: 50` still returns at most 50 elements.
- [ ] Maintainers: please run the upstream CI and test suite against this branch.