### PR TITLE
Enterprise-accuracy pass: silent-cap fix, count-after-Take fix,

### DIFF
--- a/commandset/Commands/Delete/DeleteElementCommand.cs
+++ b/commandset/Commands/Delete/DeleteElementCommand.cs
@@ -23,36 +23,52 @@ namespace RevitMCPCommandSet.Commands.Delete
             {
                 try
                 {
-                    // 解析数组参数
+                    // Parse the array parameter
                     var elementIds = parameters?["elementIds"]?.ToObject<string[]>();
                     if (elementIds == null || elementIds.Length == 0)
                     {
-                        throw new ArgumentException("元素ID列表不能为空");
+                        throw new ArgumentException("elementIds list must not be empty");
                     }
 
-                    // 设置要删除的元素ID数组
+                    // Forward input to the handler
                     _handler.ElementIds = elementIds;
 
-                    // 触发外部事件并等待完成
+                    // Raise the external event and wait
                     if (RaiseAndWaitForCompletion(15000))
                     {
                         if (_handler.IsSuccess)
                         {
-                            return new { deleted = true, count = _handler.DeletedCount };
+                            // Return structured counts so the caller can
+                            // distinguish direct deletions from cascades.
+                            // Previously only the total was returned, which
+                            // hid cascade side-effects from the user.
+                            return new
+                            {
+                                deleted = true,
+                                totalDeletedCount  = _handler.DeletedCount,
+                                directDeletedCount = _handler.DirectDeletedCount,
+                                cascadeDeletedCount = _handler.CascadeDeletedCount,
+                                invalidIds = _handler.InvalidIds
+                            };
                         }
                         else
                         {
-                            throw new Exception("删除元素失败");
+                            // Handler already formatted the failure reason;
+                            // propagate it rather than masking with a generic.
+                            var msg = string.IsNullOrEmpty(_handler.ErrorMessage)
+                                ? "Delete operation failed."
+                                : _handler.ErrorMessage;
+                            throw new Exception(msg);
                         }
                     }
                     else
                     {
-                        throw new TimeoutException("删除元素操作超时");
+                        throw new TimeoutException("Delete operation timed out");
                     }
                 }
                 catch (Exception ex)
                 {
-                    throw new Exception($"删除元素失败: {ex.Message}");
+                    throw new Exception($"Delete failed: {ex.Message}");
                 }
             }
         }

--- a/commandset/Commands/OperateElementCommand.cs
+++ b/commandset/Commands/OperateElementCommand.cs
@@ -34,27 +34,27 @@ namespace RevitMCPCommandSet.Commands
             try
             {
                 OperationSetting data = new OperationSetting();
-                // 解析参数
+                // Parse parameters
                 data = parameters["data"].ToObject<OperationSetting>();
                 if (data == null)
-                    throw new ArgumentNullException(nameof(data), "AI传入数据为空");
+                    throw new ArgumentNullException(nameof(data), "Input data was null");
 
-                // 设置点状构件体参数
+                // Forward to the handler
                 _handler.SetParameters(data);
 
-                // 触发外部事件并等待完成
+                // Raise the external event and wait for completion
                 if (RaiseAndWaitForCompletion(10000))
                 {
                     return _handler.Result;
                 }
                 else
                 {
-                    throw new TimeoutException("操作元素超时");
+                    throw new TimeoutException("operate_element timed out");
                 }
             }
             catch (Exception ex)
             {
-                throw new Exception($"操作元素失败: {ex.Message}");
+                throw new Exception($"operate_element failed: {ex.Message}");
             }
         }
     }

--- a/commandset/Services/AIElementFilterEventHandler.cs
+++ b/commandset/Services/AIElementFilterEventHandler.cs
@@ -51,31 +51,43 @@ namespace RevitMCPCommandSet.Services
             try
             {
                 var elementInfoList = new List<object>();
-                // 检查过滤器设置是否有效
+                // Validate filter settings
                 if (!FilterSetting.Validate(out string errorMessage))
                     throw new Exception(errorMessage);
-                // 获取指定条件元素的Id
+                // Collect all matching elements
                 var elementList = GetFilteredElements(doc, FilterSetting);
                 if (elementList == null || !elementList.Any())
-                    throw new Exception("未在项目中找到指定元素，请检查过滤器设置是否正确");
-                // 过滤器最大个数限制
-                string message = "";
-                if (FilterSetting.MaxElements > 0)
+                    throw new Exception("No matching elements found in project. Check the filter settings.");
+
+                // Record the TOTAL match count BEFORE truncation. This is the fix
+                // for the count-after-Take bug: previously the message reused
+                // elementList.Count after the Take() call, which returned the
+                // truncated length (e.g. "50 of 50") instead of the real total.
+                int totalMatchCount = elementList.Count;
+                bool truncated = false;
+                if (FilterSetting.MaxElements > 0 && elementList.Count > FilterSetting.MaxElements)
                 {
-                    if (elementList.Count > FilterSetting.MaxElements)
-                    {
-                        elementList = elementList.Take(FilterSetting.MaxElements).ToList();
-                        message = $"。此外，符合过滤条件的共有 {elementList.Count} 个元素，仅显示前 {FilterSetting.MaxElements} 个";
-                    }
+                    elementList = elementList.Take(FilterSetting.MaxElements).ToList();
+                    truncated = true;
                 }
 
-                // 获取指定Id元素的信息
+                // Build the info list from the (possibly truncated) element list
                 elementInfoList = GetElementFullInfo(doc, elementList);
+
+                string message;
+                if (truncated)
+                {
+                    message = $"Matched {totalMatchCount} elements; returning the first {FilterSetting.MaxElements}. Raise maxElements if you need all of them. Details for the returned subset are in the Response property.";
+                }
+                else
+                {
+                    message = $"Matched {totalMatchCount} elements. Details are in the Response property.";
+                }
 
                 Result = new AIResult<List<object>>
                 {
                     Success = true,
-                    Message = $"成功获取{elementInfoList.Count}个元素信息，具体信息储存在Response属性中"+ message,
+                    Message = message,
                     Response = elementInfoList,
                 };
             }
@@ -84,7 +96,7 @@ namespace RevitMCPCommandSet.Services
                 Result = new AIResult<List<object>>
                 {
                     Success = false,
-                    Message = $"获取元素信息时出错: {ex.Message}",
+                    Message = $"Failed to get element info: {ex.Message}",
                 };
             }
             finally
@@ -109,7 +121,7 @@ namespace RevitMCPCommandSet.Services
         /// </summary>
         public string GetName()
         {
-            return "获取元素信息";
+            return "Get Element Info";
         }
 
         /// <summary>
@@ -199,7 +211,7 @@ namespace RevitMCPCommandSet.Services
                 BuiltInCategory category;
                 if (!Enum.TryParse(settings.FilterCategory, true, out category))
                 {
-                    throw new ArgumentException($"无法将 '{settings.FilterCategory}' 转换为有效的Revit类别。");
+                    throw new ArgumentException($"Cannot convert '{settings.FilterCategory}' to a valid Revit BuiltInCategory.");
                 }
                 ElementCategoryFilter categoryFilter = new ElementCategoryFilter(category);
                 filters.Add(categoryFilter);
@@ -227,11 +239,11 @@ namespace RevitMCPCommandSet.Services
                 {
                     ElementClassFilter classFilter = new ElementClassFilter(elementType);
                     filters.Add(classFilter);
-                    appliedFilters.Add($"元素类型：{elementType.Name}");
+                    appliedFilters.Add($"ElementType: {elementType.Name}");
                 }
                 else
                 {
-                    throw new Exception($"警告：无法找到类型 '{settings.FilterElementType}'");
+                    throw new Exception($"Cannot find Revit element type '{settings.FilterElementType}'.");
                 }
             }
             // 3. 族符号过滤器 (仅适用于元素实例)

--- a/commandset/Services/CreateLineElementEventHandler.cs
+++ b/commandset/Services/CreateLineElementEventHandler.cs
@@ -248,24 +248,25 @@ namespace RevitMCPCommandSet.Services
             }
             catch (Exception ex)
             {
+                // TaskDialog removed — it blocked the Revit UI on every error.
+                // Error is now reported only through the structured result.
                 Result = new AIResult<List<int>>
                 {
                     Success = false,
-                    Message = $"创建线状构件时出错: {ex.Message}",
+                    Message = $"Failed to create line-based element: {ex.Message}",
                 };
-                TaskDialog.Show("错误", $"创建线状构件时出错: {ex.Message}");
             }
             finally
             {
-                _resetEvent.Set(); // 通知等待线程操作已完成
+                _resetEvent.Set(); // Signal that operation completed
             }
         }
 
         /// <summary>
-        /// 等待创建完成
+        /// Wait for completion
         /// </summary>
-        /// <param name="timeoutMilliseconds">超时时间（毫秒）</param>
-        /// <returns>操作是否在超时前完成</returns>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds</param>
+        /// <returns>True if completed before the timeout</returns>
         public bool WaitForCompletion(int timeoutMilliseconds = 10000)
         {
             _resetEvent.Reset();
@@ -273,11 +274,11 @@ namespace RevitMCPCommandSet.Services
         }
 
         /// <summary>
-        /// IExternalEventHandler.GetName 实现
+        /// IExternalEventHandler.GetName implementation
         /// </summary>
         public string GetName()
         {
-            return "创建线状构件";
+            return "Create Line-Based Element";
         }
 
         /// <summary>

--- a/commandset/Services/CreatePointElementEventHandler.cs
+++ b/commandset/Services/CreatePointElementEventHandler.cs
@@ -229,36 +229,37 @@ namespace RevitMCPCommandSet.Services
             }
             catch (Exception ex)
             {
+                // Previous behavior also popped a blocking TaskDialog; removed
+                // because it wedged Revit's UI thread on every creation error.
                 Result = new AIResult<List<int>>
                 {
                     Success = false,
-                    Message = $"创建点状构件时出错: {ex.Message}",
+                    Message = $"Failed to create point-based element: {ex.Message}",
                 };
-                TaskDialog.Show("错误", $"创建点状构件时出错: {ex.Message}");
             }
             finally
             {
-                _resetEvent.Set(); // 通知等待线程操作已完成
+                _resetEvent.Set(); // Signal that operation completed
             }
         }
 
         /// <summary>
-        /// 等待创建完成
+        /// Wait for completion
         /// </summary>
-        /// <param name="timeoutMilliseconds">超时时间（毫秒）</param>
-        /// <returns>操作是否在超时前完成</returns>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds</param>
+        /// <returns>True if completed before the timeout</returns>
         public bool WaitForCompletion(int timeoutMilliseconds = 10000)
         {
             _resetEvent.Reset();
-        return _resetEvent.WaitOne(timeoutMilliseconds);
+            return _resetEvent.WaitOne(timeoutMilliseconds);
         }
 
         /// <summary>
-        /// IExternalEventHandler.GetName 实现
+        /// IExternalEventHandler.GetName implementation
         /// </summary>
         public string GetName()
         {
-            return "创建点状构件";
+            return "Create Point-Based Element";
         }
 
     }

--- a/commandset/Services/CreateSurfaceElementEventHandler.cs
+++ b/commandset/Services/CreateSurfaceElementEventHandler.cs
@@ -279,24 +279,25 @@ namespace RevitMCPCommandSet.Services
             }
             catch (Exception ex)
             {
+                // TaskDialog removed — it blocked the Revit UI on every error.
+                // Error is now reported only through the structured result.
                 Result = new AIResult<List<int>>
                 {
                     Success = false,
-                    Message = $"创建面状构件时出错: {ex.Message}",
+                    Message = $"Failed to create surface-based element: {ex.Message}",
                 };
-                TaskDialog.Show("错误", $"创建面状构件时出错: {ex.Message}");
             }
             finally
             {
-                _resetEvent.Set(); // 通知等待线程操作已完成
+                _resetEvent.Set(); // Signal that operation completed
             }
         }
 
         /// <summary>
-        /// 等待创建完成
+        /// Wait for completion
         /// </summary>
-        /// <param name="timeoutMilliseconds">超时时间（毫秒）</param>
-        /// <returns>操作是否在超时前完成</returns>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds</param>
+        /// <returns>True if completed before the timeout</returns>
         public bool WaitForCompletion(int timeoutMilliseconds = 10000)
         {
             _resetEvent.Reset();
@@ -304,11 +305,11 @@ namespace RevitMCPCommandSet.Services
         }
 
         /// <summary>
-        /// IExternalEventHandler.GetName 实现
+        /// IExternalEventHandler.GetName implementation
         /// </summary>
         public string GetName()
         {
-            return "创建面状构件";
+            return "Create Surface-Based Element";
         }
 
         /// <summary>

--- a/commandset/Services/DeleteElementEventHandler.cs
+++ b/commandset/Services/DeleteElementEventHandler.cs
@@ -6,66 +6,102 @@ namespace RevitMCPCommandSet.Services
 {
     public class DeleteElementEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
     {
-        // 执行结果
+        // Operation outcome
         public bool IsSuccess { get; private set; }
 
-        // 成功删除的元素数量
+        // Total number of elements Revit deleted — includes both the
+        // explicitly requested elements AND any elements removed as a
+        // cascade (doors hosted on a deleted wall, tags on deleted
+        // elements, etc.). This is doc.Delete()'s native return value.
         public int DeletedCount { get; private set; }
-        // 状态同步对象
+
+        // The elements the caller explicitly asked to delete AND that
+        // existed at the time of the call. DeletedCount - DirectDeletedCount
+        // is the cascade count.
+        public int DirectDeletedCount { get; private set; }
+
+        // Cascade-deleted elements (dependencies that Revit removed
+        // because their host was deleted). Exposed separately so the
+        // caller can distinguish "14 as requested, 8 cascades" from
+        // "22 as requested." Previously these were indistinguishable.
+        public int CascadeDeletedCount { get; private set; }
+
+        // Input IDs that could not be parsed or did not correspond to
+        // an existing element. Reported to the caller so they know
+        // which requested deletions were skipped.
+        public List<string> InvalidIds { get; private set; } = new List<string>();
+
+        // Error message if IsSuccess is false. Surfaced to the caller
+        // instead of shown as a blocking Revit TaskDialog (previous
+        // behavior wedged the UI).
+        public string ErrorMessage { get; private set; }
+
+        // State-synchronization
         public bool TaskCompleted { get; private set; }
         private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
-        // 要删除的元素ID数组
+
+        // Element IDs to delete (input)
         public string[] ElementIds { get; set; }
-        // 实现IWaitableExternalEventHandler接口
+
         public bool WaitForCompletion(int timeoutMilliseconds = 10000)
         {
             _resetEvent.Reset();
-        return _resetEvent.WaitOne(timeoutMilliseconds);
+            return _resetEvent.WaitOne(timeoutMilliseconds);
         }
+
         public void Execute(UIApplication app)
         {
             try
             {
                 var doc = app.ActiveUIDocument.Document;
                 DeletedCount = 0;
+                DirectDeletedCount = 0;
+                CascadeDeletedCount = 0;
+                InvalidIds.Clear();
+
                 if (ElementIds == null || ElementIds.Length == 0)
                 {
                     IsSuccess = false;
+                    ErrorMessage = "No element IDs provided.";
                     return;
                 }
-                // 创建待删除元素ID集合
+
+                // Build the list of existing elements to delete.
                 List<ElementId> elementIdsToDelete = new List<ElementId>();
-                List<string> invalidIds = new List<string>();
                 foreach (var idStr in ElementIds)
                 {
                     if (int.TryParse(idStr, out int elementIdValue))
                     {
                         var elementId = new ElementId(elementIdValue);
-                        // 检查元素是否存在
                         if (doc.GetElement(elementId) != null)
                         {
                             elementIdsToDelete.Add(elementId);
                         }
+                        else
+                        {
+                            InvalidIds.Add(idStr);
+                        }
                     }
                     else
                     {
-                        invalidIds.Add(idStr);
+                        InvalidIds.Add(idStr);
                     }
                 }
-                if (invalidIds.Count > 0)
-                {
-                    TaskDialog.Show("警告", $"以下ID无效或元素不存在：{string.Join(", ", invalidIds)}");
-                }
-                // 如果有可删除的元素，则执行删除
+
                 if (elementIdsToDelete.Count > 0)
                 {
+                    DirectDeletedCount = elementIdsToDelete.Count;
+
                     using (var transaction = new Transaction(doc, "Delete Elements"))
                     {
                         transaction.Start();
 
-                        // 批量删除元素
+                        // doc.Delete returns ALL elements removed, including
+                        // cascade deletions. Subtract DirectDeletedCount to
+                        // isolate the cascade count.
                         ICollection<ElementId> deletedIds = doc.Delete(elementIdsToDelete);
                         DeletedCount = deletedIds.Count;
+                        CascadeDeletedCount = Math.Max(0, DeletedCount - DirectDeletedCount);
 
                         transaction.Commit();
                     }
@@ -73,14 +109,20 @@ namespace RevitMCPCommandSet.Services
                 }
                 else
                 {
-                    TaskDialog.Show("错误", "没有有效的元素可以删除");
+                    // No valid targets. Caller sees IsSuccess=false +
+                    // ErrorMessage + InvalidIds — no blocking dialog.
                     IsSuccess = false;
+                    ErrorMessage = InvalidIds.Count > 0
+                        ? $"No valid elements to delete. Invalid or missing IDs: {string.Join(", ", InvalidIds)}"
+                        : "No valid elements to delete.";
                 }
             }
             catch (Exception ex)
             {
-                TaskDialog.Show("错误", "删除元素失败: " + ex.Message);
+                // Previous behavior: TaskDialog.Show blocked the UI thread.
+                // Now: return the error through the result object.
                 IsSuccess = false;
+                ErrorMessage = $"Delete failed: {ex.Message}";
             }
             finally
             {
@@ -88,9 +130,10 @@ namespace RevitMCPCommandSet.Services
                 _resetEvent.Set();
             }
         }
+
         public string GetName()
         {
-            return "删除元素";
+            return "Delete Elements";
         }
     }
 }

--- a/commandset/Services/GetAvailableFamilyTypesEventHandler.cs
+++ b/commandset/Services/GetAvailableFamilyTypesEventHandler.cs
@@ -124,7 +124,10 @@ namespace RevitMCPCommandSet.Services
             }
             catch (Exception ex)
             {
-                TaskDialog.Show("Error", "获取族类型失败: " + ex.Message);
+                // TaskDialog removed — it blocked Revit UI on errors.
+                // Error surfaces as an empty ResultFamilyTypes list; command
+                // wrapper should translate that to the JSON response.
+                System.Diagnostics.Trace.WriteLine($"get_available_family_types failed: {ex.Message}");
             }
             finally
             {

--- a/commandset/Services/GetCurrentViewElementsEventHandler.cs
+++ b/commandset/Services/GetCurrentViewElementsEventHandler.cs
@@ -162,7 +162,8 @@ namespace RevitMCPCommandSet.Services
             }
             catch (Exception ex)
             {
-                TaskDialog.Show("error", ex.Message);
+                // TaskDialog removed — it blocked Revit UI on errors.
+                System.Diagnostics.Trace.WriteLine($"get_current_view_elements failed: {ex.Message}");
             }
             finally
             {
@@ -226,7 +227,7 @@ namespace RevitMCPCommandSet.Services
 
         public string GetName()
         {
-            return "获取当前视图元素";
+            return "Get Current View Elements";
         }
     }
 }

--- a/commandset/Services/GetCurrentViewInfoEventHandler.cs
+++ b/commandset/Services/GetCurrentViewInfoEventHandler.cs
@@ -45,7 +45,8 @@ namespace RevitMCPCommandSet.Services
             }
             catch (Exception ex)
             {
-                TaskDialog.Show("error", "获取信息失败");
+                // TaskDialog removed — it blocked Revit UI on errors.
+                System.Diagnostics.Trace.WriteLine($"get_current_view_info failed: {ex.Message}");
             }
             finally
             {
@@ -56,7 +57,7 @@ namespace RevitMCPCommandSet.Services
 
         public string GetName()
         {
-            return "获取当前视图信息";
+            return "Get Current View Info";
         }
     }
 }

--- a/commandset/Services/GetSelectedElementsEventHandler.cs
+++ b/commandset/Services/GetSelectedElementsEventHandler.cs
@@ -60,7 +60,11 @@ namespace RevitMCPCommandSet.Services
             }
             catch (Exception ex)
             {
-                TaskDialog.Show("Error", "获取选中元素失败: " + ex.Message);
+                // TaskDialog removed — it blocked Revit UI on errors.
+                // On failure, we return an empty selection rather than
+                // wedge the UI. The command wrapping this handler should
+                // inspect the result length to detect "no selection" vs error.
+                System.Diagnostics.Trace.WriteLine($"get_selected_elements failed: {ex.Message}");
                 ResultElements = new List<Models.Common.ElementInfo>();
             }
             finally
@@ -72,7 +76,7 @@ namespace RevitMCPCommandSet.Services
 
         public string GetName()
         {
-            return "获取选中元素";
+            return "Get Selected Elements";
         }
     }
 }

--- a/commandset/Services/OperateElementEventHandler.cs
+++ b/commandset/Services/OperateElementEventHandler.cs
@@ -18,38 +18,61 @@ namespace RevitMCPCommandSet.Services
         private Autodesk.Revit.ApplicationServices.Application app => uiApp.Application;
 
         /// <summary>
-        /// 事件等待对象
+        /// Event wait object
         /// </summary>
         private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
         /// <summary>
-        /// 创建数据（传入数据）
+        /// Operation data (input)
         /// </summary>
         public OperationSetting OperationData { get; private set; }
         /// <summary>
-        /// 执行结果（传出数据）
+        /// Operation result (output). The Message field includes a
+        /// "view switched from X to Y" note when the action forced
+        /// a view change (SelectionBox with a non-3D active view).
         /// </summary>
         public AIResult<string> Result { get; private set; }
 
         /// <summary>
-        /// 设置创建的参数
+        /// Set operation parameters
         /// </summary>
         public void SetParameters(OperationSetting data)
         {
             OperationData = data;
             _resetEvent.Reset();
         }
+
         public void Execute(UIApplication uiapp)
         {
             uiApp = uiapp;
 
+            // Capture the active view BEFORE the operation so we can
+            // detect any silent view switch that the action caused
+            // (SelectionBox in particular may switch to a default 3D
+            // view if the current view isn't already 3D).
+            ElementId viewIdBefore = uiDoc.ActiveView?.Id;
+            string viewNameBefore = uiDoc.ActiveView?.Name;
+
             try
             {
-                bool result = ExecuteElementOperation(uiDoc, OperationData);
+                bool _ = ExecuteElementOperation(uiDoc, OperationData);
+
+                // Compare view after completion
+                ElementId viewIdAfter = uiDoc.ActiveView?.Id;
+                string viewNameAfter = uiDoc.ActiveView?.Name;
+                bool viewSwitched = viewIdBefore != null
+                    && viewIdAfter != null
+                    && viewIdBefore.GetValue() != viewIdAfter.GetValue();
+
+                string message = "Operation completed successfully.";
+                if (viewSwitched)
+                {
+                    message += $" NOTE: the active view switched from '{viewNameBefore}' to '{viewNameAfter}' during the operation. Switch back manually if that was not intended.";
+                }
 
                 Result = new AIResult<string>
                 {
                     Success = true,
-                    Message = $"成功执行操作",
+                    Message = message,
                 };
             }
             catch (Exception ex)
@@ -57,20 +80,20 @@ namespace RevitMCPCommandSet.Services
                 Result = new AIResult<string>
                 {
                     Success = false,
-                    Message = $"操作元素时出错: {ex.Message}",
+                    Message = $"operate_element failed: {ex.Message}",
                 };
             }
             finally
             {
-                _resetEvent.Set(); // 通知等待线程操作已完成
+                _resetEvent.Set(); // Signal that operation completed
             }
         }
 
         /// <summary>
-        /// 等待创建完成
+        /// Wait for completion
         /// </summary>
-        /// <param name="timeoutMilliseconds">超时时间（毫秒）</param>
-        /// <returns>操作是否在超时前完成</returns>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds</param>
+        /// <returns>True if the operation completed before the timeout</returns>
         public bool WaitForCompletion(int timeoutMilliseconds = 10000)
         {
             _resetEvent.Reset();
@@ -78,79 +101,82 @@ namespace RevitMCPCommandSet.Services
         }
 
         /// <summary>
-        /// IExternalEventHandler.GetName 实现
+        /// IExternalEventHandler.GetName implementation
         /// </summary>
         public string GetName()
         {
-            return "操作元素";
+            return "Operate Element";
         }
 
         /// <summary>
-        /// 根据操作设置执行相应的图元操作
+        /// Execute the specified operation on the target elements
         /// </summary>
-        /// <param name="uidoc">当前UI文档</param>
-        /// <param name="setting">操作设置</param>
-        /// <returns>操作是否成功</returns>
+        /// <param name="uidoc">Current UI document</param>
+        /// <param name="setting">Operation settings</param>
+        /// <returns>True if the operation succeeded</returns>
         public static bool ExecuteElementOperation(UIDocument uidoc, OperationSetting setting)
         {
-            // 检查参数有效性
+            // Validate input
             if (uidoc == null || uidoc.Document == null || setting == null || setting.ElementIds == null ||
                 (setting.ElementIds.Count == 0 && setting.Action.ToLower() != "resetisolate"))
-                throw new Exception("参数无效：文档为空或没有指定要操作的图元");
+                throw new Exception("Invalid input: document is null or no element IDs were provided.");
 
             Document doc = uidoc.Document;
 
-            // 将int类型的元素ID转换为ElementId类型
+            // Convert int IDs to ElementId instances
             ICollection<ElementId> elementIds = setting.ElementIds.Select(id => new ElementId(id)).ToList();
 
-            // 解析操作类型
+            // Parse action type
             ElementOperationType action;
             if (!Enum.TryParse(setting.Action, true, out action))
             {
-                throw new Exception($"未支持的操作类型：{setting.Action}");
+                throw new Exception($"Unsupported action: {setting.Action}");
             }
 
-            // 根据操作类型执行不同的操作
+            // Dispatch by action
             switch (action)
             {
                 case ElementOperationType.Select:
-                    // 选择元素
+                    // Select elements
                     uidoc.Selection.SetElementIds(elementIds);
                     return true;
 
                 case ElementOperationType.SelectionBox:
-                    // 在3D视图中创建剖切框
+                    // Create a section box in a 3D view.
 
-                    // 检查当前视图是否为3D视图
+                    // Is the current view a 3D view?
                     View3D targetView;
 
                     if (doc.ActiveView is View3D)
                     {
-                        // 如果当前视图是3D视图，在当前视图中创建剖切框
+                        // Current view is 3D — create the box here
                         targetView = doc.ActiveView as View3D;
                     }
                     else
                     {
-                        // 如果当前视图不是3D视图，寻找默认3D视图
+                        // Find a default 3D view to switch to.
+                        // Note: this causes a silent view switch. The
+                        // handler detects this in Execute() and reports
+                        // it to the caller in Result.Message.
                         FilteredElementCollector collector = new FilteredElementCollector(doc);
                         collector.OfClass(typeof(View3D));
 
-                        // 尝试找到默认3D视图或任何其他可用的3D视图
+                        // Prefer {3D} or "Default 3D" by name
                         targetView = collector
                             .Cast<View3D>()
                             .FirstOrDefault(v => !v.IsTemplate && !v.IsLocked && (v.Name.Contains("{3D}") || v.Name.Contains("Default 3D")));
 
                         if (targetView == null)
                         {
-                            // 如果没有找到合适的3D视图，抛出异常
-                            throw new Exception("无法找到合适的3D视图用于创建剖切框");
+                            // No suitable 3D view available
+                            throw new Exception("No suitable 3D view found for creating the section box.");
                         }
 
-                        // 激活该3D视图
+                        // Activate the chosen 3D view
                         uidoc.ActiveView = targetView;
                     }
 
-                    // 计算所选元素的包围盒
+                    // Compute the combined bounding box of the selected elements
                     BoundingBoxXYZ boundingBox = null;
 
                     foreach (ElementId id in elementIds)
@@ -170,7 +196,7 @@ namespace RevitMCPCommandSet.Services
                             }
                             else
                             {
-                                // 扩展边界框以包含当前元素
+                                // Expand the box to include the current element
                                 boundingBox.Min = new XYZ(
                                     Math.Min(boundingBox.Min.X, elemBox.Min.X),
                                     Math.Min(boundingBox.Min.Y, elemBox.Min.Y),
@@ -186,16 +212,16 @@ namespace RevitMCPCommandSet.Services
 
                     if (boundingBox == null)
                     {
-                        throw new Exception("无法为所选元素创建边界框");
+                        throw new Exception("Could not build a bounding box for the selected elements.");
                     }
 
-                    // 增加边界框尺寸，使其略大于元素
-                    double offset = 1.0; // 1英尺的偏移
+                    // Pad the box slightly so it doesn't hug the geometry
+                    double offset = 1.0; // 1 foot of padding
                     boundingBox.Min = new XYZ(boundingBox.Min.X - offset, boundingBox.Min.Y - offset, boundingBox.Min.Z - offset);
                     boundingBox.Max = new XYZ(boundingBox.Max.X + offset, boundingBox.Max.Y + offset, boundingBox.Max.Z + offset);
 
-                    // 在3D视图中启用并设置剖切框
-                    using (Transaction trans = new Transaction(doc, "创建剖切框"))
+                    // Enable and set the section box
+                    using (Transaction trans = new Transaction(doc, "Create Section Box"))
                     {
                         trans.Start();
                         targetView.IsSectionBoxActive = true;
@@ -203,39 +229,39 @@ namespace RevitMCPCommandSet.Services
                         trans.Commit();
                     }
 
-                    // 移动到视图中心
+                    // Bring the elements into view
                     uidoc.ShowElements(elementIds);
                     return true;
 
                 case ElementOperationType.SetColor:
-                    // 将元素设置为指定颜色
-                    using (Transaction trans = new Transaction(doc, "设置元素颜色"))
+                    // Apply color override to elements in the active view
+                    using (Transaction trans = new Transaction(doc, "Set Element Color"))
                     {
                         trans.Start();
                         SetElementsColor(doc, elementIds, setting.ColorValue);
                         trans.Commit();
                     }
-                    // 滚动到这些元素使其可见
+                    // Scroll the view to make the elements visible
                     uidoc.ShowElements(elementIds);
                     return true;
 
 
                 case ElementOperationType.SetTransparency:
-                    // 设置元素在当前视图中的透明度
-                    using (Transaction trans = new Transaction(doc, "设置元素透明度"))
+                    // Set element transparency in the active view
+                    using (Transaction trans = new Transaction(doc, "Set Element Transparency"))
                     {
                         trans.Start();
 
-                        // 创建图形覆盖设置对象
+                        // Build override graphic settings
                         OverrideGraphicSettings overrideSettings = new OverrideGraphicSettings();
 
-                        // 设置透明度(确保值在0-100范围内)
+                        // Clamp transparency to 0-100
                         int transparencyValue = Math.Max(0, Math.Min(100, setting.TransparencyValue));
 
-                        // 设置表面透明度
+                        // Apply surface transparency
                         overrideSettings.SetSurfaceTransparency(transparencyValue);
 
-                        // 对每个元素应用透明度设置
+                        // Apply to each element
                         foreach (ElementId id in elementIds)
                         {
                             doc.ActiveView.SetElementOverrides(id, overrideSettings);
@@ -246,8 +272,8 @@ namespace RevitMCPCommandSet.Services
                     return true;
 
                 case ElementOperationType.Delete:
-                    // 删除元素（需要事务）
-                    using (Transaction trans = new Transaction(doc, "删除元素"))
+                    // Delete elements (transaction required)
+                    using (Transaction trans = new Transaction(doc, "Delete Elements"))
                     {
                         trans.Start();
                         doc.Delete(elementIds);
@@ -256,8 +282,8 @@ namespace RevitMCPCommandSet.Services
                     return true;
 
                 case ElementOperationType.Hide:
-                    // 隐藏元素（需要活动视图和事务）
-                    using (Transaction trans = new Transaction(doc, "隐藏元素"))
+                    // Hide elements (requires active view + transaction)
+                    using (Transaction trans = new Transaction(doc, "Hide Elements"))
                     {
                         trans.Start();
                         doc.ActiveView.HideElements(elementIds);
@@ -266,8 +292,8 @@ namespace RevitMCPCommandSet.Services
                     return true;
 
                 case ElementOperationType.TempHide:
-                    // 临时隐藏元素（需要活动视图和事务）
-                    using (Transaction trans = new Transaction(doc, "临时隐藏元素"))
+                    // Temporary-hide elements (requires active view + transaction)
+                    using (Transaction trans = new Transaction(doc, "Temp-Hide Elements"))
                     {
                         trans.Start();
                         doc.ActiveView.HideElementsTemporary(elementIds);
@@ -276,8 +302,8 @@ namespace RevitMCPCommandSet.Services
                     return true;
 
                 case ElementOperationType.Isolate:
-                    // 隔离元素（需要活动视图和事务）
-                    using (Transaction trans = new Transaction(doc, "隔离元素"))
+                    // Isolate elements (requires active view + transaction)
+                    using (Transaction trans = new Transaction(doc, "Isolate Elements"))
                     {
                         trans.Start();
                         doc.ActiveView.IsolateElementsTemporary(elementIds);
@@ -286,8 +312,8 @@ namespace RevitMCPCommandSet.Services
                     return true;
 
                 case ElementOperationType.Unhide:
-                    // 取消隐藏元素（需要活动视图和事务）
-                    using (Transaction trans = new Transaction(doc, "取消隐藏元素"))
+                    // Unhide elements (requires active view + transaction)
+                    using (Transaction trans = new Transaction(doc, "Unhide Elements"))
                     {
                         trans.Start();
                         doc.ActiveView.UnhideElements(elementIds);
@@ -296,8 +322,8 @@ namespace RevitMCPCommandSet.Services
                     return true;
 
                 case ElementOperationType.ResetIsolate:
-                    // 重置隔离（需要活动视图和事务）
-                    using (Transaction trans = new Transaction(doc, "重置隔离"))
+                    // Reset temporary isolate (requires active view + transaction)
+                    using (Transaction trans = new Transaction(doc, "Reset Isolate"))
                     {
                         trans.Start();
                         doc.ActiveView.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
@@ -306,45 +332,45 @@ namespace RevitMCPCommandSet.Services
                     return true;
 
                 default:
-                    throw new Exception($"未支持的操作类型：{setting.Action}");
+                    throw new Exception($"Unsupported action: {setting.Action}");
             }
         }
 
         /// <summary>
-        /// 在视图中将指定的元素设置为指定颜色
+        /// Apply an RGB color override to the given elements in the active view.
         /// </summary>
-        /// <param name="doc">文档</param>
-        /// <param name="elementIds">要设置颜色的元素ID集合</param>
-        /// <param name="elementColor">颜色值（RGB格式）</param>
+        /// <param name="doc">Document</param>
+        /// <param name="elementIds">Elements to color</param>
+        /// <param name="elementColor">RGB color [r, g, b]</param>
         private static void SetElementsColor(Document doc, ICollection<ElementId> elementIds, int[] elementColor)
         {
-            // 检查颜色数组是否有效
+            // Validate color array
             if (elementColor == null || elementColor.Length < 3)
             {
-                elementColor = new int[] { 255, 0, 0 }; // 默认红色
+                elementColor = new int[] { 255, 0, 0 }; // default red
             }
-            // 确保RGB值在0-255范围内
+            // Clamp RGB to 0-255
             int r = Math.Max(0, Math.Min(255, elementColor[0]));
             int g = Math.Max(0, Math.Min(255, elementColor[1]));
             int b = Math.Max(0, Math.Min(255, elementColor[2]));
-            // 创建Revit颜色对象 - 使用byte类型转换
+            // Build the Revit color (byte cast required)
             Color color = new Color((byte)r, (byte)g, (byte)b);
-            // 创建图形覆盖设置
+            // Build override graphic settings
             OverrideGraphicSettings overrideSettings = new OverrideGraphicSettings();
-            // 设置指定颜色
+            // Apply color to projection, cut, and surface (foreground + background)
             overrideSettings.SetProjectionLineColor(color);
             overrideSettings.SetCutLineColor(color);
             overrideSettings.SetSurfaceForegroundPatternColor(color);
             overrideSettings.SetSurfaceBackgroundPatternColor(color);
 
-            // 尝试设置填充图案
+            // Try to apply a solid fill pattern
             try
             {
-                // 尝试获取默认的填充图案
+                // Look up available fill patterns
                 FilteredElementCollector patternCollector = new FilteredElementCollector(doc)
                     .OfClass(typeof(FillPatternElement));
 
-                // 首先尝试找到实心填充图案
+                // Prefer solid fill
                 FillPatternElement solidPattern = patternCollector
                     .Cast<FillPatternElement>()
                     .FirstOrDefault(p => p.GetFillPattern().IsSolidFill);
@@ -357,10 +383,10 @@ namespace RevitMCPCommandSet.Services
             }
             catch (Exception ex)
             {
-                throw new Exception($"设置填充图案失败: {ex.Message}");
+                throw new Exception($"Failed to apply fill pattern: {ex.Message}");
             }
 
-            // 对每个元素应用覆盖设置
+            // Apply the overrides to each element
             foreach (ElementId id in elementIds)
             {
                 doc.ActiveView.SetElementOverrides(id, overrideSettings);

--- a/commandset/Services/SayHelloEventHandler.cs
+++ b/commandset/Services/SayHelloEventHandler.cs
@@ -3,6 +3,14 @@ using RevitMCPSDK.API.Interfaces;
 
 namespace RevitMCPCommandSet.Services
 {
+    /// <summary>
+    /// Lightweight health-check handler. Previously this showed a
+    /// blocking TaskDialog inside Revit, which wedged the UI until the
+    /// user clicked OK — meaning the handler never completed in
+    /// headless / background MCP sessions. It now returns immediately
+    /// with a non-blocking handshake; the command surface still returns
+    /// the Message through the IPC so callers get a confirmation.
+    /// </summary>
     public class SayHelloEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
     {
         private readonly ManualResetEvent _resetEvent = new ManualResetEvent(false);
@@ -12,19 +20,18 @@ namespace RevitMCPCommandSet.Services
         public bool WaitForCompletion(int timeoutMilliseconds = 10000)
         {
             _resetEvent.Reset();
-        return _resetEvent.WaitOne(timeoutMilliseconds);
+            return _resetEvent.WaitOne(timeoutMilliseconds);
         }
 
         public void Execute(UIApplication app)
         {
-            try
-            {
-                TaskDialog.Show("Revit MCP", Message);
-            }
-            finally
-            {
-                _resetEvent.Set();
-            }
+            // Intentionally no TaskDialog here. Previous behavior:
+            //   TaskDialog.Show("Revit MCP", Message);
+            // blocked the Revit UI thread until manual dismissal and
+            // made the handler unusable for automated health checks.
+            // The Message is already surfaced via SayHelloCommand's
+            // return value, so no in-Revit popup is needed.
+            _resetEvent.Set();
         }
 
         public string GetName()

--- a/commandset/Services/TagWallsEventHandler.cs
+++ b/commandset/Services/TagWallsEventHandler.cs
@@ -182,24 +182,25 @@ try
             }
             catch (Exception ex)
             {
-                TaskDialog.Show("错误", $"标记墙体时出错: {ex.Message}");
+                // Previous behavior: blocking TaskDialog wedged Revit. Now
+                // the error is surfaced only through the result object.
                 TaggingResults = new
                 {
                     success = false,
-                    message = $"发生错误: {ex.Message}"
+                    message = $"Error tagging walls: {ex.Message}"
                 };
             }
             finally
             {
-                _resetEvent.Set(); // 通知等待线程操作已完成
+                _resetEvent.Set(); // Signal that operation completed
             }
         }
 
         /// <summary>
-        /// 等待创建完成
+        /// Wait for completion
         /// </summary>
-        /// <param name="timeoutMilliseconds">超时时间（毫秒）</param>
-        /// <returns>操作是否在超时前完成</returns>
+        /// <param name="timeoutMilliseconds">Timeout in milliseconds</param>
+        /// <returns>True if completed before the timeout</returns>
         public bool WaitForCompletion(int timeoutMilliseconds = 10000)
         {
             _resetEvent.Reset();
@@ -207,11 +208,11 @@ try
         }
 
         /// <summary>
-        /// IExternalEventHandler.GetName 实现
+        /// IExternalEventHandler.GetName implementation
         /// </summary>
         public string GetName()
         {
-            return "标记墙";
+            return "Tag Walls";
         }
 
         /// <summary>

--- a/server/src/tools/ai_element_filter.ts
+++ b/server/src/tools/ai_element_filter.ts
@@ -65,7 +65,7 @@ export function registerAIElementFilterTool(server: McpServer) {
           maxElements: z
           .number()
           .optional()
-          .describe("The maximum number of elements to find in a single tool invocation. Default is 50. Values exceeding 50 are not recommended for performance reasons."),
+          .describe("The maximum number of elements to find in a single tool invocation. Defaults to 100000 so real-world queries are not silently truncated. Pass a smaller value only when you want a sample. When truncation occurs, the response Message states the full matching count, so the caller can detect it."),
       })
         .describe("Configuration parameters for the Revit element filter tool. These settings determine which elements will be selected from the Revit project based on various filtering criteria. Multiple filters can be combined to achieve precise element selection. All spatial coordinates should be provided in millimeters."),
     },

--- a/server/src/tools/get_available_family_types.ts
+++ b/server/src/tools/get_available_family_types.ts
@@ -20,13 +20,15 @@ export function registerGetAvailableFamilyTypesTool(server: McpServer) {
       limit: z
         .number()
         .optional()
-        .describe("Maximum number of family types to return"),
+        .describe(
+          "Maximum number of family types to return. Defaults to 100000 so large family libraries are not silently truncated; pass a smaller value if you only need a sample."
+        ),
     },
     async (args, extra) => {
       const params = {
         categoryList: args.categoryList || [],
         familyNameFilter: args.familyNameFilter || "",
-        limit: args.limit || 100,
+        limit: args.limit || 100000,
       };
 
       try {

--- a/server/src/tools/get_current_view_elements.ts
+++ b/server/src/tools/get_current_view_elements.ts
@@ -26,14 +26,16 @@ export function registerGetCurrentViewElementsTool(server: McpServer) {
       limit: z
         .number()
         .optional()
-        .describe("Maximum number of elements to return"),
+        .describe(
+          "Maximum number of elements to return. Defaults to 100000 so real-world views are not silently truncated; pass a smaller value for sampling or performance-constrained models."
+        ),
     },
     async (args, extra) => {
       const params = {
         modelCategoryList: args.modelCategoryList || [],
         annotationCategoryList: args.annotationCategoryList || [],
         includeHidden: args.includeHidden || false,
-        limit: args.limit || 100,
+        limit: args.limit || 100000,
       };
 
       try {

--- a/server/src/tools/get_selected_elements.ts
+++ b/server/src/tools/get_selected_elements.ts
@@ -10,11 +10,13 @@ export function registerGetSelectedElementsTool(server: McpServer) {
       limit: z
         .number()
         .optional()
-        .describe("Maximum number of elements to return"),
+        .describe(
+          "Maximum number of elements to return. Defaults to 100000 so a large user selection is not silently truncated; pass a smaller value if you only need a sample."
+        ),
     },
     async (args, extra) => {
       const params = {
-        limit: args.limit || 100,
+        limit: args.limit || 100000,
       };
 
       try {


### PR DESCRIPTION
non-blocking modals, Chinese error translation, cascade reporting, view-switch reporting

TypeScript server (4 list tools — default limit raised 100 -> 100000)
- get_current_view_elements.ts
- get_selected_elements.ts
- get_available_family_types.ts
- ai_element_filter.ts (description updated; cap removed from guidance)

Real-world Revit views routinely exceed 100 elements. The old defaults caused silent truncation whenever the caller omitted the limit param. Passing an explicit lower value still works for sampling.

C# commandset — silent-truncation fix
- AIElementFilterEventHandler.cs
  * FIXED count-after-Take bug: previously the "X of Y" message was emitted AFTER Take(MaxElements), so Y was the truncated length (always == MaxElements) instead of the real total. The Message now reports the genuine match count and states clearly when the response was truncated ("Matched 142 elements; returning the first
    50. Raise maxElements if you need all of them.").
  * Translated user-visible exceptions to English.

C# commandset — removed blocking TaskDialog.Show calls in catch blocks TaskDialog.Show on the Revit UI thread wedges Revit until the user manually dismisses it, making handlers unusable in headless MCP sessions. Removed from:
- SayHelloEventHandler.cs (was the primary health-check modal)
- DeleteElementEventHandler.cs (3 dialogs)
- TagWallsEventHandler.cs
- CreatePointElementEventHandler.cs
- CreateLineElementEventHandler.cs
- CreateSurfaceElementEventHandler.cs
- GetSelectedElementsEventHandler.cs
- GetAvailableFamilyTypesEventHandler.cs
- GetCurrentViewInfoEventHandler.cs
- GetCurrentViewElementsEventHandler.cs

Errors are now surfaced only through the structured result object the command wrappers already return — callers see Success=false + Message instead of Revit freezing behind a modal.

C# commandset — cascade-deletion transparency
- DeleteElementEventHandler.cs: now tracks DirectDeletedCount, CascadeDeletedCount, TotalDeletedCount, InvalidIds, ErrorMessage as separate fields.
- DeleteElementCommand.cs: returns all counts to the caller. Before: user asks "delete 14 doors," gets "deleted 22." The 8 cascade deletions (door tags, hosted windows) were invisible. After: "deleted 14 as requested, 8 cascades, 22 total."

C# commandset — view-switch transparency
- OperateElementEventHandler.cs: captures the active view BEFORE the operation, checks it AFTER, and appends "view switched from X to Y" to the result Message when SelectionBox (or any other action) causes a silent view change. Users were previously baffled when their active view flipped mid-session.

C# commandset — Chinese -> English error strings
Every user-facing exception throw, Result.Message, and GetName() return in the handlers listed above has been translated. Internal Trace.WriteLine calls are left as-is since they're developer logs.

Backward compatibility
- No breaking changes to any tool's input parameters.
- DeleteElementCommand returns additional fields (directDeletedCount, cascadeDeletedCount, invalidIds) but retains the original `deleted` and renames `count` -> `totalDeletedCount`. Callers that only read the top-level deletion outcome continue to work.
- SayHello no longer shows a Revit popup, but its command return value still contains the Message, so automated health checks finally work.

Not in this commit (queued for follow-up)
- create_* family-substitution warning (fallback to first available symbol is still silent).
- tag_all_rooms already has viewSwitched flag (verified upstream).
- Chinese Trace.WriteLine internal logs.