### PR TITLE
fix: deduplicate Roslyn assembly references to fix send_code_to_revit on BIM360 installs

### DIFF
--- a/commandset/Commands/ExecuteDynamicCode/ExecuteCodeEventHandler.cs
+++ b/commandset/Commands/ExecuteDynamicCode/ExecuteCodeEventHandler.cs
@@ -117,9 +117,11 @@ namespace AIGeneratedCode
 
             var syntaxTree = CSharpSyntaxTree.ParseText(wrappedCode);
 
-            // 添加必要的程序集引用（引用所有已加载的程序集）
+            // 添加必要的程序集引用（引用所有已加载的程序集，按简单名称去重以避免冲突）
             var references = AppDomain.CurrentDomain.GetAssemblies()
                 .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+                .GroupBy(a => a.GetName().Name)
+                .Select(g => g.First())
                 .Select(a => MetadataReference.CreateFromFile(a.Location))
                 .Cast<MetadataReference>()
                 .ToList();


### PR DESCRIPTION
## Summary

- Adds `.GroupBy(a => a.GetName().Name).Select(g => g.First())` to the assembly reference collection in `ExecuteCodeEventHandler.CompileAndExecuteCode`
- Deduplicates assemblies by simple name before passing them to Roslyn's `CSharpCompilation`

## Problem

On Revit installs that include the **BIM360 add-in** (`Autodesk.Bim360.Revit.Issues.Addin`), that add-in ships its own copies of several Autodesk SDK DLLs (`Autodesk.JsonApi`, `Autodesk.Http`, `Autodesk.Extensions`, etc.) that have the same simple name as DLLs already loaded by Revit itself.

`AppDomain.CurrentDomain.GetAssemblies()` returns both copies. When all of them are passed to `CSharpCompilation` as `MetadataReference`s, Roslyn raises fatal errors for every duplicate:

```
Line 0: An assembly with the same simple name 'Autodesk.JsonApi' has already been imported.
Line 0: An assembly with the same simple name 'Autodesk.Http' has already been imported.
...
```

These are **Line 0 errors** — they block compilation entirely regardless of what user code is submitted. `send_code_to_revit` is completely unusable on any machine with BIM360 installed.

## Fix

```csharp
var references = AppDomain.CurrentDomain.GetAssemblies()
    .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
    .GroupBy(a => a.GetName().Name)   // deduplicate by simple name
    .Select(g => g.First())
    .Select(a => MetadataReference.CreateFromFile(a.Location))
    .Cast<MetadataReference>()
    .ToList();
```

When multiple assemblies share the same simple name, the first one loaded wins (Revit's own copy). The duplicate from BIM360 is silently skipped — matching the behaviour the CLR itself uses when resolving assembly bindings.

## Testing

Verified on Revit 2025 with `Autodesk.Bim360.Revit.Issues.Addin` loaded — `send_code_to_revit` now compiles and executes successfully after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
